### PR TITLE
Release/v1.0.0 rc.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v1.0.0-rc.8
+### Interfaces
+- Add IUpdateable#lastUpdateTime and IUpdateable#timeSinceLastUpdate
+- Add IAccumulator to define common functions
+- Remove `getLastObservation` and `getCurrentObservation` from accumulators
+
+### Accumulators
+- Initialize accumulators when initializing instead of just the observation
+- Validate all observations instead of only the ones after the first update
+- Add AbstractAccumulator to define common logic and reduce redundancy
+- Add convenience functions: `changeThresholdSurpassed(address token, uint256 changeThreshold)` and `updateThresholdSurpassed(address token)`
+- Make consultations use stored observations by default, rather than returning data directly from the source
+  - A `maxAge` of 0 allows for the consultation to return data directly from the source
+
+### Oracles
+- Make PeriodicAccumulationOracle only update observation timestamp and emit Updated when it has enough information to calculate a price
+
+### Libraries
+ - Remove unused UniswapV2PriceAccumulator data structure
+
 ## v1.0.0-rc.7
 ### Accumulators
 - Add observation validation against externally provided data (MEV and flashbot attack protection)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pythia Core
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-![606 out of 606 tests passing](https://img.shields.io/badge/tests-606/606%20passing-brightgreen.svg?style=flat-square)
+![614 out of 614 tests passing](https://img.shields.io/badge/tests-614/614%20passing-brightgreen.svg?style=flat-square)
 ![test-coverage 100%](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg?style=flat-square)
 
 Pythia Core is a set of Solidity smart contracts for building EVM oracle solutions.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pythia Core
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-![618 out of 618 tests passing](https://img.shields.io/badge/tests-618/618%20passing-brightgreen.svg?style=flat-square)
+![620 out of 620 tests passing](https://img.shields.io/badge/tests-620/620%20passing-brightgreen.svg?style=flat-square)
 ![test-coverage 100%](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg?style=flat-square)
 
 Pythia Core is a set of Solidity smart contracts for building EVM oracle solutions.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pythia Core
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-![614 out of 614 tests passing](https://img.shields.io/badge/tests-614/614%20passing-brightgreen.svg?style=flat-square)
+![618 out of 618 tests passing](https://img.shields.io/badge/tests-618/618%20passing-brightgreen.svg?style=flat-square)
 ![test-coverage 100%](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg?style=flat-square)
 
 Pythia Core is a set of Solidity smart contracts for building EVM oracle solutions.

--- a/contracts/accumulators/AbstractAccumulator.sol
+++ b/contracts/accumulators/AbstractAccumulator.sol
@@ -1,0 +1,73 @@
+//SPDX-License-Identifier: MIT
+pragma solidity =0.8.11;
+
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin-v4/contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin-v4/contracts/utils/math/SafeCast.sol";
+
+import "../interfaces/IAccumulator.sol";
+
+abstract contract AbstractAccumulator is IERC165, IAccumulator {
+    uint256 public immutable override changePrecision = 10**8;
+
+    uint256 public immutable override updateThreshold;
+
+    constructor(uint256 updateThreshold_) {
+        updateThreshold = updateThreshold_;
+    }
+
+    /// @inheritdoc IAccumulator
+    function updateThresholdSurpassed(address token) public view virtual override returns (bool) {
+        return changeThresholdSurpassed(token, updateThreshold);
+    }
+
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IAccumulator).interfaceId;
+    }
+
+    function calculateChange(uint256 a, uint256 b) internal view virtual returns (uint256 change, bool isInfinite) {
+        // Ensure a is never smaller than b
+        if (a < b) {
+            uint256 temp = a;
+            a = b;
+            b = temp;
+        }
+
+        // a >= b
+
+        if (a == 0) {
+            // a == b == 0 (since a >= b), therefore no change
+            return (0, false);
+        } else if (b == 0) {
+            // (a > 0 && b == 0) => change threshold passed
+            // Zero to non-zero always returns true
+            return (0, true);
+        }
+
+        unchecked {
+            uint256 delta = a - b; // a >= b, therefore no underflow
+            uint256 preciseDelta = delta * changePrecision;
+
+            // If the delta is so large that multiplying by CHANGE_PRECISION overflows, we assume that
+            // the change threshold has been surpassed.
+            // If our assumption is incorrect, the accumulator will be extra-up-to-date, which won't
+            // really break anything, but will cost more gas in keeping this accumulator updated.
+            if (preciseDelta < delta) return (0, true);
+
+            change = preciseDelta / b;
+            isInfinite = false;
+        }
+    }
+
+    function changeThresholdSurpassed(
+        uint256 a,
+        uint256 b,
+        uint256 changeThreshold
+    ) internal view virtual returns (bool) {
+        (uint256 change, bool isInfinite) = calculateChange(a, b);
+
+        return isInfinite || change >= changeThreshold;
+    }
+}

--- a/contracts/accumulators/LiquidityAccumulator.sol
+++ b/contracts/accumulators/LiquidityAccumulator.sol
@@ -87,7 +87,7 @@ abstract contract LiquidityAccumulator is
     /// @param data The encoded address of the token for which to perform the update.
     /// @inheritdoc IUpdateable
     function needsUpdate(bytes memory data) public view virtual override returns (bool) {
-        uint256 deltaTime = block.timestamp - lastUpdateTime(data);
+        uint256 deltaTime = timeSinceLastUpdate(data);
         if (deltaTime < minUpdateDelay) {
             // Ensures updates occur at most once every minUpdateDelay (seconds)
             return false;
@@ -122,11 +122,18 @@ abstract contract LiquidityAccumulator is
         return false;
     }
 
+    /// @param data The encoded address of the token for which the update relates to.
     /// @inheritdoc IUpdateable
     function lastUpdateTime(bytes memory data) public view virtual override returns (uint256) {
         address token = abi.decode(data, (address));
 
         return observations[token].timestamp;
+    }
+
+    /// @param data The encoded address of the token for which the update relates to.
+    /// @inheritdoc IUpdateable
+    function timeSinceLastUpdate(bytes memory data) public view virtual override returns (uint256) {
+        return block.timestamp - lastUpdateTime(data);
     }
 
     /// @inheritdoc ILiquidityAccumulator

--- a/contracts/accumulators/LiquidityAccumulator.sol
+++ b/contracts/accumulators/LiquidityAccumulator.sol
@@ -165,29 +165,6 @@ abstract contract LiquidityAccumulator is IERC165, ILiquidityAccumulator, ILiqui
         }
     }
 
-    /// @inheritdoc ILiquidityAccumulator
-    function getLastObservation(address token)
-        public
-        view
-        virtual
-        override
-        returns (ObservationLibrary.LiquidityObservation memory)
-    {
-        return observations[token];
-    }
-
-    /// @inheritdoc ILiquidityAccumulator
-    function getCurrentObservation(address token)
-        public
-        view
-        virtual
-        override
-        returns (ObservationLibrary.LiquidityObservation memory observation)
-    {
-        (observation.tokenLiquidity, observation.quoteTokenLiquidity) = fetchLiquidity(token);
-        observation.timestamp = block.timestamp.toUint32();
-    }
-
     /// @inheritdoc IERC165
     function supportsInterface(bytes4 interfaceId)
         public
@@ -370,7 +347,7 @@ abstract contract LiquidityAccumulator is IERC165, ILiquidityAccumulator, ILiqui
     ) internal view virtual returns (bool) {
         (uint256 change, bool isInfinite) = calculateChange(a, b);
 
-        return isInfinite || change > changeThreshold;
+        return isInfinite || change >= changeThreshold;
     }
 
     function fetchLiquidity(address token)

--- a/contracts/accumulators/PriceAccumulator.sol
+++ b/contracts/accumulators/PriceAccumulator.sol
@@ -80,10 +80,7 @@ abstract contract PriceAccumulator is
     /// @param data The encoded address of the token for which to perform the update.
     /// @inheritdoc IUpdateable
     function needsUpdate(bytes memory data) public view virtual override returns (bool) {
-        address token = abi.decode(data, (address));
-
-        ObservationLibrary.PriceObservation storage lastObservation = observations[token];
-        uint256 deltaTime = block.timestamp - lastObservation.timestamp;
+        uint256 deltaTime = block.timestamp - lastUpdateTime(data);
         if (deltaTime < minUpdateDelay) {
             // Ensures updates occur at most once every minUpdateDelay (seconds)
             return false;
@@ -97,6 +94,8 @@ abstract contract PriceAccumulator is
          *
          * Check if the % change in price warrants an update (saves gas vs. always updating on change)
          */
+        address token = abi.decode(data, (address));
+
         return updateThresholdSurpassed(token);
     }
 
@@ -114,6 +113,13 @@ abstract contract PriceAccumulator is
         if (needsUpdate(data)) return performUpdate(data);
 
         return false;
+    }
+
+    /// @inheritdoc IUpdateable
+    function lastUpdateTime(bytes memory data) public view virtual override returns (uint256) {
+        address token = abi.decode(data, (address));
+
+        return observations[token].timestamp;
     }
 
     /// @inheritdoc IPriceAccumulator

--- a/contracts/accumulators/PriceAccumulator.sol
+++ b/contracts/accumulators/PriceAccumulator.sol
@@ -55,6 +55,28 @@ abstract contract PriceAccumulator is IERC165, IPriceAccumulator, IPriceOracle, 
         }
     }
 
+    /// @notice Determines whether the specified change threshold has been surpassed for the specified token.
+    /// @dev Calculates the change from the stored observation to the current observation.
+    /// @param token The token to check.
+    /// @param changeThreshold The change threshold as a percentage multiplied by the change precision
+    ///   (`changePrecision`). Ex: a 1% change is respresented as 0.01 * `changePrecision`.
+    /// @return surpassed True if the update threshold has been surpassed; false otherwise.
+    function changeThresholdSurpassed(address token, uint256 changeThreshold) public view virtual returns (bool) {
+        uint256 price = fetchPrice(token);
+
+        ObservationLibrary.PriceObservation storage lastObservation = observations[token];
+
+        return changeThresholdSurpassed(price, lastObservation.price, changeThreshold);
+    }
+
+    /// @notice Determines whether the update threshold has been surpassed for the specified token.
+    /// @dev Calculates the change from the stored observation to the current observation.
+    /// @param token The token to check.
+    /// @return surpassed True if the update threshold has been surpassed; false otherwise.
+    function updateThresholdSurpassed(address token) public view virtual returns (bool) {
+        return changeThresholdSurpassed(token, updateThreshold);
+    }
+
     /// @notice Checks if this accumulator needs an update by checking the time since the last update and the change in
     ///   liquidities.
     /// @param data The encoded address of the token for which to perform the update.
@@ -77,10 +99,7 @@ abstract contract PriceAccumulator is IERC165, IPriceAccumulator, IPriceOracle, 
          *
          * Check if the % change in price warrants an update (saves gas vs. always updating on change)
          */
-
-        uint256 price = fetchPrice(token);
-
-        return changeThresholdSurpassed(price, lastObservation.price, updateThreshold);
+        return updateThresholdSurpassed(token);
     }
 
     /// @param data The encoded address of the token for which to perform the update.
@@ -276,11 +295,7 @@ abstract contract PriceAccumulator is IERC165, IPriceAccumulator, IPriceOracle, 
         return !changeThresholdSurpassed(price, pPrice, allowedChangeThreshold);
     }
 
-    function changeThresholdSurpassed(
-        uint256 a,
-        uint256 b,
-        uint256 updateTheshold
-    ) internal view virtual returns (bool) {
+    function calculateChange(uint256 a, uint256 b) internal view virtual returns (uint256 change, bool isInfinite) {
         // Ensure a is never smaller than b
         if (a < b) {
             uint256 temp = a;
@@ -292,11 +307,11 @@ abstract contract PriceAccumulator is IERC165, IPriceAccumulator, IPriceOracle, 
 
         if (a == 0) {
             // a == b == 0 (since a >= b), therefore no change
-            return false;
+            return (0, false);
         } else if (b == 0) {
             // (a > 0 && b == 0) => change threshold passed
             // Zero to non-zero always returns true
-            return true;
+            return (0, true);
         }
 
         unchecked {
@@ -307,12 +322,21 @@ abstract contract PriceAccumulator is IERC165, IPriceAccumulator, IPriceOracle, 
             // the change threshold has been surpassed.
             // If our assumption is incorrect, the accumulator will be extra-up-to-date, which won't
             // really break anything, but will cost more gas in keeping this accumulator updated.
-            if (preciseDelta < delta) return true;
+            if (preciseDelta < delta) return (0, true);
 
-            uint256 change = preciseDelta / b;
-
-            return change >= updateTheshold;
+            change = preciseDelta / b;
+            isInfinite = false;
         }
+    }
+
+    function changeThresholdSurpassed(
+        uint256 a,
+        uint256 b,
+        uint256 changeThreshold
+    ) internal view virtual returns (bool) {
+        (uint256 change, bool isInfinite) = calculateChange(a, b);
+
+        return isInfinite || change >= changeThreshold;
     }
 
     function fetchPrice(address token) internal view virtual returns (uint112 price);

--- a/contracts/accumulators/PriceAccumulator.sol
+++ b/contracts/accumulators/PriceAccumulator.sol
@@ -80,7 +80,7 @@ abstract contract PriceAccumulator is
     /// @param data The encoded address of the token for which to perform the update.
     /// @inheritdoc IUpdateable
     function needsUpdate(bytes memory data) public view virtual override returns (bool) {
-        uint256 deltaTime = block.timestamp - lastUpdateTime(data);
+        uint256 deltaTime = timeSinceLastUpdate(data);
         if (deltaTime < minUpdateDelay) {
             // Ensures updates occur at most once every minUpdateDelay (seconds)
             return false;
@@ -115,11 +115,18 @@ abstract contract PriceAccumulator is
         return false;
     }
 
+    /// @param data The encoded address of the token for which the update relates to.
     /// @inheritdoc IUpdateable
     function lastUpdateTime(bytes memory data) public view virtual override returns (uint256) {
         address token = abi.decode(data, (address));
 
         return observations[token].timestamp;
+    }
+
+    /// @param data The encoded address of the token for which the update relates to.
+    /// @inheritdoc IUpdateable
+    function timeSinceLastUpdate(bytes memory data) public view virtual override returns (uint256) {
+        return block.timestamp - lastUpdateTime(data);
     }
 
     /// @inheritdoc IPriceAccumulator

--- a/contracts/accumulators/PriceAccumulator.sol
+++ b/contracts/accumulators/PriceAccumulator.sol
@@ -156,29 +156,6 @@ abstract contract PriceAccumulator is IERC165, IPriceAccumulator, IPriceOracle, 
         }
     }
 
-    /// @inheritdoc IPriceAccumulator
-    function getLastObservation(address token)
-        public
-        view
-        virtual
-        override
-        returns (ObservationLibrary.PriceObservation memory)
-    {
-        return observations[token];
-    }
-
-    /// @inheritdoc IPriceAccumulator
-    function getCurrentObservation(address token)
-        public
-        view
-        virtual
-        override
-        returns (ObservationLibrary.PriceObservation memory observation)
-    {
-        observation.price = fetchPrice(token);
-        observation.timestamp = block.timestamp.toUint32();
-    }
-
     /// @inheritdoc IERC165
     function supportsInterface(bytes4 interfaceId)
         public

--- a/contracts/interfaces/IAccumulator.sol
+++ b/contracts/interfaces/IAccumulator.sol
@@ -1,0 +1,31 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0 <0.9.0;
+
+/**
+ * @title IAccumulator
+ * @notice An interface that defines an accumulator - that is, a contract that updates cumulative value(s) when the
+ *   underlying value(s) change by more than the update threshold.
+ */
+abstract contract IAccumulator {
+    /// @notice Gets the scalar (as a power of 10) to be used for calculating changes in value.
+    /// @return The scalar to be used for calculating changes in value.
+    function changePrecision() external view virtual returns (uint256);
+
+    /// @notice Gets the threshold at which an update to the cumulative value(s) should be performed.
+    /// @return A percentage scaled by the change precision.
+    function updateThreshold() external view virtual returns (uint256);
+
+    /// @notice Determines whether the specified change threshold has been surpassed for the specified token.
+    /// @dev Calculates the change from the stored observation to the current observation.
+    /// @param token The token to check.
+    /// @param changeThreshold The change threshold as a percentage multiplied by the change precision
+    ///   (`changePrecision`). Ex: a 1% change is respresented as 0.01 * `changePrecision`.
+    /// @return surpassed True if the update threshold has been surpassed; false otherwise.
+    function changeThresholdSurpassed(address token, uint256 changeThreshold) public view virtual returns (bool);
+
+    /// @notice Determines whether the update threshold has been surpassed for the specified token.
+    /// @dev Calculates the change from the stored observation to the current observation.
+    /// @param token The token to check.
+    /// @return surpassed True if the update threshold has been surpassed; false otherwise.
+    function updateThresholdSurpassed(address token) public view virtual returns (bool);
+}

--- a/contracts/interfaces/ILiquidityAccumulator.sol
+++ b/contracts/interfaces/ILiquidityAccumulator.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.5.0 <0.9.0;
 
 pragma experimental ABIEncoderV2;
 
-import "./IUpdateable.sol";
+import "./IAccumulator.sol";
 
 import "../libraries/AccumulationLibrary.sol";
 import "../libraries/ObservationLibrary.sol";
@@ -14,7 +14,7 @@ import "../libraries/ObservationLibrary.sol";
  *   single quote token and many exchange tokens.
  * @dev Liquidity accumulators are used to calculate time-weighted average liquidity levels.
  */
-abstract contract ILiquidityAccumulator is IUpdateable {
+abstract contract ILiquidityAccumulator is IAccumulator {
     /// @notice Emitted when the accumulator is updated.
     /// @dev The accumulator's observation and cumulative values are updated when this is emitted.
     /// @param token The address of the token that the update is for.
@@ -22,10 +22,6 @@ abstract contract ILiquidityAccumulator is IUpdateable {
     /// @param quoteTokenLiquidity The amount of the quote token that is liquid in the underlying pool, in wei.
     /// @param timestamp The epoch timestamp of the update (in seconds).
     event Updated(address indexed token, uint256 tokenLiquidity, uint256 quoteTokenLiquidity, uint256 timestamp);
-
-    /// @notice Gets the scalar (as a power of 10) to be used for calculating changes in liquidity levels.
-    /// @return The scalar to be used for calculating changes in liquidity levels.
-    function changePrecision() external view virtual returns (uint256);
 
     /**
      * @notice Calculates a liquidity levels from two different cumulative liquidity levels.

--- a/contracts/interfaces/ILiquidityAccumulator.sol
+++ b/contracts/interfaces/ILiquidityAccumulator.sol
@@ -60,22 +60,4 @@ abstract contract ILiquidityAccumulator is IUpdateable {
         view
         virtual
         returns (AccumulationLibrary.LiquidityAccumulator memory);
-
-    /// @notice Gets the last calculated time-weighted average liquidity levels of a token and the quote token.
-    /// @param token The address of the token to get the liquidity levels for (with the quote token).
-    /// @return The last liquidity levels (in wei) along with the timestamp of those levels.
-    function getLastObservation(address token)
-        public
-        view
-        virtual
-        returns (ObservationLibrary.LiquidityObservation memory);
-
-    /// @notice Gets the current calculated time-weighted average liquidity levels of a token and the quote token.
-    /// @param token The address of the token to get the liquidity levels for (with the quote token).
-    /// @return The current liquidity levels (in wei) along with the timestamp of those levels.
-    function getCurrentObservation(address token)
-        public
-        view
-        virtual
-        returns (ObservationLibrary.LiquidityObservation memory);
 }

--- a/contracts/interfaces/IPriceAccumulator.sol
+++ b/contracts/interfaces/IPriceAccumulator.sol
@@ -56,18 +56,4 @@ abstract contract IPriceAccumulator is IUpdateable {
         view
         virtual
         returns (AccumulationLibrary.PriceAccumulator memory);
-
-    /// @notice Gets the last calculated time-weighted average price of a token.
-    /// @param token The address of the token to get the price for.
-    /// @return The last price along with the timestamp of that price.
-    function getLastObservation(address token) public view virtual returns (ObservationLibrary.PriceObservation memory);
-
-    /// @notice Gets the current calculated time-weighted average price of a token.
-    /// @param token The address of the token to get the price for.
-    /// @return The current price along with the timestamp of that price.
-    function getCurrentObservation(address token)
-        public
-        view
-        virtual
-        returns (ObservationLibrary.PriceObservation memory);
 }

--- a/contracts/interfaces/IPriceAccumulator.sol
+++ b/contracts/interfaces/IPriceAccumulator.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.5.0 <0.9.0;
 
 pragma experimental ABIEncoderV2;
 
-import "./IUpdateable.sol";
+import "./IAccumulator.sol";
 
 import "../libraries/AccumulationLibrary.sol";
 import "../libraries/ObservationLibrary.sol";
@@ -14,17 +14,13 @@ import "../libraries/ObservationLibrary.sol";
  *   and many exchange tokens.
  * @dev Price accumulators are used to calculate time-weighted average prices.
  */
-abstract contract IPriceAccumulator is IUpdateable {
+abstract contract IPriceAccumulator is IAccumulator {
     /// @notice Emitted when the accumulator is updated.
     /// @dev The accumulator's observation and cumulative values are updated when this is emitted.
     /// @param token The address of the token that the update is for.
     /// @param price The quote token denominated price for a whole token.
     /// @param timestamp The epoch timestamp of the update (in seconds).
     event Updated(address indexed token, uint256 price, uint256 timestamp);
-
-    /// @notice Gets the scalar (as a power of 10) to be used for calculating changes in price.
-    /// @return The scalar to be used for calculating changes in price.
-    function changePrecision() external view virtual returns (uint256);
 
     /**
      * @notice Calculates a price from two different cumulative prices.

--- a/contracts/interfaces/IUpdateable.sol
+++ b/contracts/interfaces/IUpdateable.sol
@@ -25,4 +25,9 @@ abstract contract IUpdateable {
     /// @param data Any data relating to the update.
     /// @return A unix timestamp.
     function lastUpdateTime(bytes memory data) public view virtual returns (uint256);
+
+    /// @notice Gets the amount of time (in seconds) since the last update.
+    /// @param data Any data relating to the update.
+    /// @return Time in seconds.
+    function timeSinceLastUpdate(bytes memory data) public view virtual returns (uint256);
 }

--- a/contracts/interfaces/IUpdateable.sol
+++ b/contracts/interfaces/IUpdateable.sol
@@ -20,4 +20,9 @@ abstract contract IUpdateable {
     /// @param data Any data relating to the update.
     /// @return b True if an update can be performed by the caller; false otherwise.
     function canUpdate(bytes memory data) public view virtual returns (bool b);
+
+    /// @notice Gets the timestamp of the last update.
+    /// @param data Any data relating to the update.
+    /// @return A unix timestamp.
+    function lastUpdateTime(bytes memory data) public view virtual returns (uint256);
 }

--- a/contracts/libraries/AccumulationLibrary.sol
+++ b/contracts/libraries/AccumulationLibrary.sol
@@ -52,25 +52,4 @@ library AccumulationLibrary {
          */
         uint32 timestamp;
     }
-
-    /**
-     * @notice A struct for storing a snapshot of price Uniswap V2 accumulations.
-     * @dev The difference of a newer snapshot against an older snapshot can be used to derive a time-weighted average
-     *   price by dividing the difference in value by the difference in time.
-     *
-     * Uniswap V2 prices are stored in a unique format requiring 256 bits.
-     */
-    struct UniswapV2PriceAccumulator {
-        /*
-         * @notice Accumulates time-weighted average prices in the form of a sumation of (price * time), with time
-         *   measured in seconds.
-         * @dev Overflow is desired and results in correct behavior as long as the difference between two snapshots
-         *   is less than or equal to 2^256.
-         */
-        uint256 cumulativePrice;
-        /*
-         * @notice The unix timestamp (in seconds) of the last update of (addition to) the cumulative price.
-         */
-        uint32 timestamp;
-    }
 }

--- a/contracts/oracles/AbstractOracle.sol
+++ b/contracts/oracles/AbstractOracle.sol
@@ -25,12 +25,18 @@ abstract contract AbstractOracle is IERC165, IOracle, SimpleQuotationMetadata {
     /// @inheritdoc IUpdateable
     function canUpdate(bytes memory data) public view virtual override returns (bool);
 
-    /// @param data The encoded address of the token for which to perform the update.
+    /// @param data The encoded address of the token for which the update relates to.
     /// @inheritdoc IUpdateable
     function lastUpdateTime(bytes memory data) public view virtual override returns (uint256) {
         address token = abi.decode(data, (address));
 
         return observations[token].timestamp;
+    }
+
+    /// @param data The encoded address of the token for which the update relates to.
+    /// @inheritdoc IUpdateable
+    function timeSinceLastUpdate(bytes memory data) public view virtual override returns (uint256) {
+        return block.timestamp - lastUpdateTime(data);
     }
 
     function consultPrice(address token) public view virtual override returns (uint112 price) {

--- a/contracts/oracles/AbstractOracle.sol
+++ b/contracts/oracles/AbstractOracle.sol
@@ -25,6 +25,14 @@ abstract contract AbstractOracle is IERC165, IOracle, SimpleQuotationMetadata {
     /// @inheritdoc IUpdateable
     function canUpdate(bytes memory data) public view virtual override returns (bool);
 
+    /// @param data The encoded address of the token for which to perform the update.
+    /// @inheritdoc IUpdateable
+    function lastUpdateTime(bytes memory data) public view virtual override returns (uint256) {
+        address token = abi.decode(data, (address));
+
+        return observations[token].timestamp;
+    }
+
     function consultPrice(address token) public view virtual override returns (uint112 price) {
         if (token == quoteTokenAddress()) return uint112(10**quoteTokenDecimals());
 

--- a/contracts/oracles/PeriodicAccumulationOracle.sol
+++ b/contracts/oracles/PeriodicAccumulationOracle.sol
@@ -52,6 +52,8 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
             AccumulationLibrary.PriceAccumulator memory freshAccumulation = IPriceAccumulator(priceAccumulator)
                 .getCurrentAccumulation(token);
 
+            AccumulationLibrary.PriceAccumulator storage lastAccumulation = priceAccumulations[token];
+
             uint256 lastAccumulationTime = priceAccumulations[token].timestamp;
 
             if (freshAccumulation.timestamp > lastAccumulationTime) {
@@ -60,12 +62,13 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
                 if (lastAccumulationTime != 0) {
                     // We have two accumulations -> calculate price from them
                     observation.price = IPriceAccumulator(priceAccumulator).calculatePrice(
-                        priceAccumulations[token],
+                        lastAccumulation,
                         freshAccumulation
                     );
                 }
 
-                priceAccumulations[token] = freshAccumulation;
+                lastAccumulation.cumulativePrice = freshAccumulation.cumulativePrice;
+                lastAccumulation.timestamp = freshAccumulation.timestamp;
             }
         }
 
@@ -80,7 +83,7 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
 
             AccumulationLibrary.LiquidityAccumulator storage lastAccumulation = liquidityAccumulations[token];
 
-            uint256 lastAccumulationTime = lastAccumulation.timestamp;
+            uint256 lastAccumulationTime = liquidityAccumulations[token].timestamp;
 
             if (freshAccumulation.timestamp > lastAccumulationTime) {
                 // Accumulator updated, so we update our observation

--- a/contracts/oracles/PeriodicOracle.sol
+++ b/contracts/oracles/PeriodicOracle.sol
@@ -21,9 +21,7 @@ abstract contract PeriodicOracle is IPeriodic, AbstractOracle {
 
     /// @inheritdoc AbstractOracle
     function needsUpdate(bytes memory data) public view virtual override returns (bool) {
-        address token = abi.decode(data, (address));
-
-        uint256 deltaTime = block.timestamp - observations[token].timestamp;
+        uint256 deltaTime = block.timestamp - lastUpdateTime(data);
 
         return deltaTime >= period;
     }

--- a/contracts/oracles/PeriodicOracle.sol
+++ b/contracts/oracles/PeriodicOracle.sol
@@ -21,9 +21,7 @@ abstract contract PeriodicOracle is IPeriodic, AbstractOracle {
 
     /// @inheritdoc AbstractOracle
     function needsUpdate(bytes memory data) public view virtual override returns (bool) {
-        uint256 deltaTime = block.timestamp - lastUpdateTime(data);
-
-        return deltaTime >= period;
+        return timeSinceLastUpdate(data) >= period;
     }
 
     /// @inheritdoc AbstractOracle

--- a/contracts/test/InterfaceIds.sol
+++ b/contracts/test/InterfaceIds.sol
@@ -12,6 +12,7 @@ import "../interfaces/IPriceAccumulator.sol";
 import "../interfaces/IPriceOracle.sol";
 import "../interfaces/IQuoteToken.sol";
 import "../interfaces/IUpdateable.sol";
+import "../interfaces/IAccumulator.sol";
 
 contract InterfaceIds {
     function iAggregatedOracle() external pure returns (bytes4) {
@@ -56,5 +57,9 @@ contract InterfaceIds {
 
     function iUpdateable() external pure returns (bytes4) {
         return type(IUpdateable).interfaceId;
+    }
+
+    function iAccumulator() external pure returns (bytes4) {
+        return type(IAccumulator).interfaceId;
     }
 }

--- a/contracts/test/accumulators/LiquidityAccumulatorStub.sol
+++ b/contracts/test/accumulators/LiquidityAccumulatorStub.sol
@@ -78,6 +78,14 @@ contract LiquidityAccumulatorStub is LiquidityAccumulator {
         return super.validateObservation(updateData, tokenLiquidity, quoteTokenLiquidity);
     }
 
+    function stubFetchLiquidity(address token)
+        public
+        view
+        returns (uint256 tokenLiquidity, uint256 quoteTokenLiquidity)
+    {
+        return fetchLiquidity(token);
+    }
+
     function harnessChangeThresholdSurpassed(
         uint256 a,
         uint256 b,

--- a/contracts/test/accumulators/LiquidityAccumulatorStub.sol
+++ b/contracts/test/accumulators/LiquidityAccumulatorStub.sol
@@ -42,6 +42,19 @@ contract LiquidityAccumulatorStub is LiquidityAccumulator {
         liquidity.quoteTokenLiquidity = quoteTokenLiquidity;
     }
 
+    function stubSetObservation(
+        address token,
+        uint112 tokenLiquidity,
+        uint112 quoteTokenLiquidity,
+        uint32 timestamp
+    ) public {
+        ObservationLibrary.LiquidityObservation storage observation = observations[token];
+
+        observation.tokenLiquidity = tokenLiquidity;
+        observation.quoteTokenLiquidity = quoteTokenLiquidity;
+        observation.timestamp = timestamp;
+    }
+
     function overrideChangeThresholdPassed(bool overridden, bool changeThresholdPassed) public {
         config.changeThresholdOverridden = overridden;
         config.changeThresholdPassed = changeThresholdPassed;

--- a/contracts/test/accumulators/PriceAccumulatorStub.sol
+++ b/contracts/test/accumulators/PriceAccumulatorStub.sol
@@ -30,6 +30,17 @@ contract PriceAccumulatorStub is PriceAccumulator {
         mockPrices[token] = price;
     }
 
+    function stubSetObservation(
+        address token,
+        uint112 price,
+        uint32 timestamp
+    ) public {
+        ObservationLibrary.PriceObservation storage observation = observations[token];
+
+        observation.price = price;
+        observation.timestamp = timestamp;
+    }
+
     function overrideChangeThresholdPassed(bool overridden, bool changeThresholdPassed) public {
         config.changeThresholdOverridden = overridden;
         config.changeThresholdPassed = changeThresholdPassed;

--- a/contracts/test/accumulators/PriceAccumulatorStub.sol
+++ b/contracts/test/accumulators/PriceAccumulatorStub.sol
@@ -56,6 +56,10 @@ contract PriceAccumulatorStub is PriceAccumulator {
         config.validateObservation = validateObservation_;
     }
 
+    function stubFetchPrice(address token) public view returns (uint256 price) {
+        return fetchPrice(token);
+    }
+
     function harnessChangeThresholdSurpassed(
         uint256 a,
         uint256 b,

--- a/contracts/test/oracles/PeriodicAccumulationOracleStub.sol
+++ b/contracts/test/oracles/PeriodicAccumulationOracleStub.sol
@@ -47,12 +47,12 @@ contract PeriodicAccumulationOracleStub is PeriodicAccumulationOracle {
 
     function performUpdate(bytes memory data) internal virtual override returns (bool) {
         // Always keep the liquidity accumulator updated so that we don't have to do so in our tests.
-        try ILiquidityAccumulator(liquidityAccumulator).update(data) returns (bool) {} catch Error(
-            string memory
-        ) {} catch (bytes memory) {}
+        try IUpdateable(liquidityAccumulator).update(data) returns (bool) {} catch Error(string memory) {} catch (
+            bytes memory
+        ) {}
 
         // Always keep the price accumulator updated so that we don't have to do so in our tests.
-        try IPriceAccumulator(priceAccumulator).update(data) returns (bool) {} catch Error(string memory) {} catch (
+        try IUpdateable(priceAccumulator).update(data) returns (bool) {} catch Error(string memory) {} catch (
             bytes memory
         ) {}
 

--- a/contracts/test/oracles/PeriodicAccumulationOracleStub.sol
+++ b/contracts/test/oracles/PeriodicAccumulationOracleStub.sol
@@ -33,6 +33,24 @@ contract PeriodicAccumulationOracleStub is PeriodicAccumulationOracle {
         observation.timestamp = timestamp;
     }
 
+    function stubSetAccumulations(
+        address token,
+        uint112 cumulativePrice,
+        uint112 cumulativeTokenLiquidity,
+        uint112 cumulativeQuoteTokenLiquidity,
+        uint32 timestamp
+    ) public {
+        AccumulationLibrary.LiquidityAccumulator storage liquidityAccumulation = liquidityAccumulations[token];
+        AccumulationLibrary.PriceAccumulator storage priceAccumulation = priceAccumulations[token];
+
+        priceAccumulation.cumulativePrice = cumulativePrice;
+        priceAccumulation.timestamp = timestamp;
+
+        liquidityAccumulation.cumulativeTokenLiquidity = cumulativeTokenLiquidity;
+        liquidityAccumulation.cumulativeQuoteTokenLiquidity = cumulativeQuoteTokenLiquidity;
+        liquidityAccumulation.timestamp = timestamp;
+    }
+
     function overrideNeedsUpdate(bool overridden, bool needsUpdate_) public {
         config.needsUpdateOverridden = overridden;
         config.needsUpdate = needsUpdate_;

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -3,6 +3,7 @@ require("solidity-coverage");
 require("hardhat-gas-reporter");
 require("hardhat-tracer");
 require("@atixlabs/hardhat-time-n-mine");
+require("hardhat-contract-sizer");
 
 const SOLC_8 = {
     version: "0.8.11",

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -10,7 +10,7 @@ const SOLC_8 = {
     settings: {
         optimizer: {
             enabled: true,
-            runs: 20000,
+            runs: 2000,
         },
     },
 };
@@ -20,7 +20,7 @@ const SOLC_7 = {
     settings: {
         optimizer: {
             enabled: true,
-            runs: 20000,
+            runs: 2000,
         },
     },
 };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ethereum-waffle": "^4.0.0-alpha.0",
     "ethers": "^5.6.1",
     "hardhat": "2.9.1",
+    "hardhat-contract-sizer": "^2.5.1",
     "hardhat-gas-reporter": "^1.0.8",
     "hardhat-tracer": "^1.0.0-alpha.6",
     "prettier": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythia-oracle/pythia-core",
-  "version": "1.0.0-rc.7",
+  "version": "1.0.0-rc.8",
   "main": "index.js",
   "author": "TRILEZ SOFTWARE INC.",
   "license": "MIT",

--- a/scripts/consult-aggregate.js
+++ b/scripts/consult-aggregate.js
@@ -198,8 +198,8 @@ async function main() {
         try {
             if (await uniswapV2.liquidityAccumulator.canUpdate(updateData)) {
                 const [tokenLiquidity, quoteTokenLiquidity] = await uniswapV2.liquidityAccumulator[
-                    "consultLiquidity(address)"
-                ](token);
+                    "consultLiquidity(address,uint256)"
+                ](token, 0);
 
                 const laUpdateData = ethers.utils.defaultAbiCoder.encode(
                     ["address", "uint", "uint"],
@@ -220,7 +220,7 @@ async function main() {
             }
 
             if (await uniswapV2.priceAccumulator.canUpdate(updateData)) {
-                const price = await uniswapV2.priceAccumulator["consultPrice(address)"](token);
+                const price = await uniswapV2.priceAccumulator["consultPrice(address,uint256)"](token, 0);
 
                 const paUpdateData = ethers.utils.defaultAbiCoder.encode(["address", "uint"], [token, price]);
 
@@ -239,8 +239,8 @@ async function main() {
 
             if (await uniswapV3.liquidityAccumulator.canUpdate(updateData)) {
                 const [tokenLiquidity, quoteTokenLiquidity] = await uniswapV3.liquidityAccumulator[
-                    "consultLiquidity(address)"
-                ](token);
+                    "consultLiquidity(address,uint256)"
+                ](token, 0);
 
                 const laUpdateData = ethers.utils.defaultAbiCoder.encode(
                     ["address", "uint", "uint"],
@@ -261,7 +261,7 @@ async function main() {
             }
 
             if (await uniswapV3.priceAccumulator.canUpdate(updateData)) {
-                const price = await uniswapV3.priceAccumulator["consultPrice(address)"](token);
+                const price = await uniswapV3.priceAccumulator["consultPrice(address,uint256)"](token, 0);
 
                 const paUpdateData = ethers.utils.defaultAbiCoder.encode(["address", "uint"], [token, price]);
 
@@ -280,8 +280,8 @@ async function main() {
 
             if (await sushiswap.liquidityAccumulator.canUpdate(updateData)) {
                 const [tokenLiquidity, quoteTokenLiquidity] = await sushiswap.liquidityAccumulator[
-                    "consultLiquidity(address)"
-                ](token);
+                    "consultLiquidity(address,uint256)"
+                ](token, 0);
 
                 const laUpdateData = ethers.utils.defaultAbiCoder.encode(
                     ["address", "uint", "uint"],
@@ -302,7 +302,7 @@ async function main() {
             }
 
             if (await sushiswap.priceAccumulator.canUpdate(updateData)) {
-                const price = await sushiswap.priceAccumulator["consultPrice(address)"](token);
+                const price = await sushiswap.priceAccumulator["consultPrice(address,uint256)"](token, 0);
 
                 const paUpdateData = ethers.utils.defaultAbiCoder.encode(["address", "uint"], [token, price]);
 

--- a/scripts/consult-curve-steth.js
+++ b/scripts/consult-curve-steth.js
@@ -96,8 +96,8 @@ async function main() {
         try {
             if (await curve.liquidityAccumulator.canUpdate(updateData)) {
                 const [tokenLiquidity, quoteTokenLiquidity] = await curve.liquidityAccumulator[
-                    "consultLiquidity(address)"
-                ](token);
+                    "consultLiquidity(address,uint256)"
+                ](token, 0);
 
                 const laUpdateData = ethers.utils.defaultAbiCoder.encode(
                     ["address", "uint", "uint"],
@@ -118,7 +118,7 @@ async function main() {
             }
 
             if (await curve.priceAccumulator.canUpdate(updateData)) {
-                const price = await curve.priceAccumulator["consultPrice(address)"](token);
+                const price = await curve.priceAccumulator["consultPrice(address,uint256)"](token, 0);
 
                 const paUpdateData = ethers.utils.defaultAbiCoder.encode(["address", "uint"], [token, price]);
 

--- a/scripts/consult-uniswap-v2.js
+++ b/scripts/consult-uniswap-v2.js
@@ -98,8 +98,8 @@ async function main() {
         try {
             if (await uniswapV2.liquidityAccumulator.canUpdate(updateData)) {
                 const [tokenLiquidity, quoteTokenLiquidity] = await uniswapV2.liquidityAccumulator[
-                    "consultLiquidity(address)"
-                ](token);
+                    "consultLiquidity(address,uint256)"
+                ](token, 0);
 
                 const laUpdateData = ethers.utils.defaultAbiCoder.encode(
                     ["address", "uint", "uint"],
@@ -120,7 +120,7 @@ async function main() {
             }
 
             if (await uniswapV2.priceAccumulator.canUpdate(updateData)) {
-                const price = await uniswapV2.priceAccumulator["consultPrice(address)"](token);
+                const price = await uniswapV2.priceAccumulator["consultPrice(address,uint256)"](token, 0);
 
                 const paUpdateData = ethers.utils.defaultAbiCoder.encode(["address", "uint"], [token, price]);
 

--- a/scripts/consult-uniswap-v3.js
+++ b/scripts/consult-uniswap-v3.js
@@ -100,8 +100,8 @@ async function main() {
         try {
             if (await uniswapV3.liquidityAccumulator.canUpdate(updateData)) {
                 const [tokenLiquidity, quoteTokenLiquidity] = await uniswapV3.liquidityAccumulator[
-                    "consultLiquidity(address)"
-                ](token);
+                    "consultLiquidity(address,uint256)"
+                ](token, 0);
 
                 const laUpdateData = ethers.utils.defaultAbiCoder.encode(
                     ["address", "uint", "uint"],
@@ -122,7 +122,7 @@ async function main() {
             }
 
             if (await uniswapV3.priceAccumulator.canUpdate(updateData)) {
-                const price = await uniswapV3.priceAccumulator["consultPrice(address)"](token);
+                const price = await uniswapV3.priceAccumulator["consultPrice(address,uint256)"](token, 0);
 
                 const paUpdateData = ethers.utils.defaultAbiCoder.encode(["address", "uint"], [token, price]);
 

--- a/scripts/interface-ids.js
+++ b/scripts/interface-ids.js
@@ -1,0 +1,19 @@
+const hre = require("hardhat");
+
+const ethers = hre.ethers;
+
+async function main() {
+    const factory = await ethers.getContractFactory("InterfaceIds");
+    const interfaceIds = await factory.deploy();
+
+    console.log("IAggregatedOracle interfaceId =", await interfaceIds.iAggregatedOracle());
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/test/liquidity-accumulator/liquidity-accumulator-test.js
+++ b/test/liquidity-accumulator/liquidity-accumulator-test.js
@@ -111,6 +111,9 @@ describe("LiquidityAccumulator#needsUpdate", () => {
         // Override changeThresholdPassed (false)
         await liquidityAccumulator.overrideChangeThresholdPassed(true, false);
 
+        // Override validateObservation
+        await liquidityAccumulator.overrideValidateObservation(true, true);
+
         // Time increases by 1 second with each block mined
         await hre.timeAndMine.setTimeIncrease(1);
 
@@ -1153,8 +1156,12 @@ describe("LiquidityAccumulator#update", () => {
 
             const deltaTime = firstUpdateTime - initialUpdateTime;
 
-            const expectedCumulativeTokenLiquidity = initialTokenLiquidity.mul(BigNumber.from(deltaTime));
-            const expectedCumulativeQuoteTokenLiquidity = initialQuoteTokenLiquidity.mul(BigNumber.from(deltaTime));
+            const expectedCumulativeTokenLiquidity = initialTokenLiquidity.add(
+                initialTokenLiquidity.mul(BigNumber.from(deltaTime))
+            );
+            const expectedCumulativeQuoteTokenLiquidity = initialQuoteTokenLiquidity.add(
+                initialQuoteTokenLiquidity.mul(BigNumber.from(deltaTime))
+            );
 
             const accumulation = await liquidityAccumulator.getLastAccumulation(GRT);
             const observation = await liquidityAccumulator.observations(GRT);
@@ -1202,8 +1209,8 @@ describe("LiquidityAccumulator#update", () => {
         const accumulation = await liquidityAccumulator.getLastAccumulation(GRT);
         const observation = await liquidityAccumulator.observations(GRT);
 
-        expect(accumulation["cumulativeTokenLiquidity"]).to.equal(0);
-        expect(accumulation["cumulativeQuoteTokenLiquidity"]).to.equal(0);
+        expect(accumulation["cumulativeTokenLiquidity"]).to.equal(initialTokenLiquidity);
+        expect(accumulation["cumulativeQuoteTokenLiquidity"]).to.equal(initialQuoteTokenLiquidity);
 
         expect(observation["tokenLiquidity"]).to.equal(initialTokenLiquidity);
         expect(observation["quoteTokenLiquidity"]).to.equal(initialQuoteTokenLiquidity);

--- a/test/liquidity-accumulator/liquidity-accumulator-test.js
+++ b/test/liquidity-accumulator/liquidity-accumulator-test.js
@@ -1245,6 +1245,16 @@ describe("LiquidityAccumulator#supportsInterface(interfaceId)", function () {
         const interfaceId = await interfaceIds.iQuoteToken();
         expect(await liquidityAccumulator["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
     });
+
+    it("Should support IUpdateable", async () => {
+        const interfaceId = await interfaceIds.iUpdateable();
+        expect(await liquidityAccumulator["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
+    });
+
+    it("Should support IAccumulator", async () => {
+        const interfaceId = await interfaceIds.iAccumulator();
+        expect(await liquidityAccumulator["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
+    });
 });
 
 describe("LiquidityAccumulator#consultLiquidity(token)", function () {

--- a/test/liquidity-accumulator/liquidity-accumulator-test.js
+++ b/test/liquidity-accumulator/liquidity-accumulator-test.js
@@ -20,7 +20,7 @@ async function blockTimestamp(blockNum) {
     return (await ethers.provider.getBlock(blockNum)).timestamp;
 }
 
-describe("LiquidityAccumulator#getCurrentObservation", function () {
+describe("LiquidityAccumulator#fetchLiquidity", function () {
     const minUpdateDelay = 10000;
     const maxUpdateDelay = 30000;
 
@@ -55,13 +55,10 @@ describe("LiquidityAccumulator#getCurrentObservation", function () {
             // Configure liquidity
             await liquidityAccumulator.setLiquidity(GRT, test[0], test[1]);
 
-            const [tokenLiquidity, quoteTokenLiquidity, timestamp] = await liquidityAccumulator.getCurrentObservation(
-                GRT
-            );
+            const { tokenLiquidity, quoteTokenLiquidity } = await liquidityAccumulator.stubFetchLiquidity(GRT);
 
             expect(tokenLiquidity).to.equal(test[0]);
             expect(quoteTokenLiquidity).to.equal(test[1]);
-            expect(timestamp).to.equal(await currentBlockTimestamp());
         });
     }
 });
@@ -856,7 +853,7 @@ describe("LiquidityAccumulator#update", () => {
         const updateTime = (await ethers.provider.getBlock(receipt.blockNumber)).timestamp;
 
         const accumulation = await liquidityAccumulator.getLastAccumulation(GRT);
-        const observation = await liquidityAccumulator.getLastObservation(GRT);
+        const observation = await liquidityAccumulator.observations(GRT);
 
         var expectedCumulativeTokenLiquidity = 0;
         var expectedCumulativeQuoteTokenLiquidity = 0;
@@ -982,7 +979,7 @@ describe("LiquidityAccumulator#update", () => {
         const updateTime2 = (await ethers.provider.getBlock(receipt2.blockNumber)).timestamp;
 
         const accumulation2 = await liquidityAccumulator.getLastAccumulation(GRT);
-        const observation2 = await liquidityAccumulator.getLastObservation(GRT);
+        const observation2 = await liquidityAccumulator.observations(GRT);
 
         const deltaTime2 = updateTime2 - updateTime;
 
@@ -1160,7 +1157,7 @@ describe("LiquidityAccumulator#update", () => {
             const expectedCumulativeQuoteTokenLiquidity = initialQuoteTokenLiquidity.mul(BigNumber.from(deltaTime));
 
             const accumulation = await liquidityAccumulator.getLastAccumulation(GRT);
-            const observation = await liquidityAccumulator.getLastObservation(GRT);
+            const observation = await liquidityAccumulator.observations(GRT);
 
             expect(accumulation["cumulativeTokenLiquidity"], "CTL").to.equal(expectedCumulativeTokenLiquidity);
             expect(accumulation["cumulativeQuoteTokenLiquidity"], "CQTL").to.equal(
@@ -1203,7 +1200,7 @@ describe("LiquidityAccumulator#update", () => {
         await expect(firstUpdateReceipt).to.not.emit(liquidityAccumulator, "Updated");
 
         const accumulation = await liquidityAccumulator.getLastAccumulation(GRT);
-        const observation = await liquidityAccumulator.getLastObservation(GRT);
+        const observation = await liquidityAccumulator.observations(GRT);
 
         expect(accumulation["cumulativeTokenLiquidity"]).to.equal(0);
         expect(accumulation["cumulativeQuoteTokenLiquidity"]).to.equal(0);

--- a/test/oracles/periodic-accumulation-oracle.js
+++ b/test/oracles/periodic-accumulation-oracle.js
@@ -88,7 +88,7 @@ describe("PeriodicAccumulationOracle#needsUpdate", function () {
         await hre.timeAndMine.setTimeIncrease(1);
     });
 
-    it("Should require an update if no observations have been made", async () => {
+    it("Should require an update if no observations or accumulations have been made", async () => {
         expect(await oracle.needsUpdate(ethers.utils.hexZeroPad(AddressZero, 32))).to.equal(true);
     });
 
@@ -96,6 +96,7 @@ describe("PeriodicAccumulationOracle#needsUpdate", function () {
         const observationTime = await currentBlockTimestamp();
 
         await oracle.stubSetObservation(AddressZero, 1, 1, 1, observationTime);
+        await oracle.stubSetAccumulations(AddressZero, 1, 1, 1, observationTime);
 
         await hre.timeAndMine.setTime(observationTime + PERIOD);
 
@@ -107,6 +108,7 @@ describe("PeriodicAccumulationOracle#needsUpdate", function () {
         const observationTime = await currentBlockTimestamp();
 
         await oracle.stubSetObservation(AddressZero, 1, 1, 1, observationTime);
+        await oracle.stubSetAccumulations(AddressZero, 1, 1, 1, observationTime);
 
         await hre.timeAndMine.setTime(observationTime + PERIOD + 1);
 
@@ -114,10 +116,11 @@ describe("PeriodicAccumulationOracle#needsUpdate", function () {
         expect(await oracle.needsUpdate(ethers.utils.hexZeroPad(AddressZero, 32))).to.equal(true);
     });
 
-    it("Shouldm't require an update if deltaTime < period", async () => {
+    it("Shouldn't require an update if deltaTime < period", async () => {
         const observationTime = await currentBlockTimestamp();
 
         await oracle.stubSetObservation(AddressZero, 1, 1, 1, observationTime);
+        await oracle.stubSetAccumulations(AddressZero, 1, 1, 1, observationTime);
 
         await hre.timeAndMine.setTime(observationTime + PERIOD - 1);
 
@@ -125,10 +128,11 @@ describe("PeriodicAccumulationOracle#needsUpdate", function () {
         expect(await oracle.needsUpdate(ethers.utils.hexZeroPad(AddressZero, 32))).to.equal(false);
     });
 
-    it("Shouldm't require an update if deltaTime == 0", async () => {
+    it("Shouldn't require an update if deltaTime == 0", async () => {
         const observationTime = (await currentBlockTimestamp()) + 10;
 
         await oracle.stubSetObservation(AddressZero, 1, 1, 1, observationTime);
+        await oracle.stubSetAccumulations(AddressZero, 1, 1, 1, observationTime);
 
         await hre.timeAndMine.setTime(observationTime);
 

--- a/test/oracles/periodic-accumulation-oracle.js
+++ b/test/oracles/periodic-accumulation-oracle.js
@@ -881,6 +881,104 @@ describe("PeriodicAccumulationOracle#update", function () {
         expectedPrice = price;
     }
 
+    it("Shouldn't update anything if the current accumulations' timestamps equals the last", async function () {
+        // Time increases by 1 second with each block mined
+        await hre.timeAndMine.setTimeIncrease(1);
+
+        const realTokenLiquidity = BigNumber.from(1000);
+        const realQuoteTokenLiquidity = BigNumber.from(20000);
+
+        // Add liquidity. Price = 20.
+        await addLiquidity(realTokenLiquidity, realQuoteTokenLiquidity);
+
+        const updateData = ethers.utils.hexZeroPad(token.address, 32);
+
+        // Update accumulators
+        await liquidityAccumulator.update(updateData);
+        await priceAccumulator.update(updateData);
+
+        const fakeAccumulationTimestamp = (await currentBlockTimestamp()) + 100;
+        const fakeObservationTimestamp = BigNumber.from(1);
+        const fakePrice = BigNumber.from(1);
+        const fakeTokenLiquidity = BigNumber.from(1);
+        const fakeQuoteTokenLiquidity = BigNumber.from(1);
+
+        await oracle.stubSetObservation(
+            token.address,
+            fakePrice,
+            fakeTokenLiquidity,
+            fakeQuoteTokenLiquidity,
+            fakeObservationTimestamp
+        );
+
+        await oracle.stubSetAccumulations(
+            token.address,
+            fakePrice,
+            fakeTokenLiquidity,
+            fakeQuoteTokenLiquidity,
+            fakeAccumulationTimestamp
+        );
+
+        // Make sure that we perform an update
+        await oracle.overrideNeedsUpdate(true, true);
+
+        // Next block timestamp will equal fakeAccumulationTimestamp
+        await hre.timeAndMine.setTime(fakeAccumulationTimestamp - 1);
+
+        const updateTx = await oracle.update(updateData);
+
+        expect(updateTx).to.not.emit(oracle, "Updated");
+
+        const [oPrice, oTokenLiqudity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token.address);
+
+        expect(oPrice, "Observation price").to.equal(fakePrice);
+        expect(oTokenLiqudity, "Observation token liquidity").to.equal(fakeTokenLiquidity);
+        expect(oQuoteTokenLiquidity, "Observation quote token liquidity").to.equal(fakeQuoteTokenLiquidity);
+        expect(oTimestamp, "Observation timestamp").to.equal(fakeObservationTimestamp);
+
+        const [cumulativePrice, cumulativePriceTimestamp] = await oracle.priceAccumulations(token.address);
+        const [cumulativeTokenLiquidity, cumulativeQuoteTokenLiquidity, cumulativeLiquidityTimestamp] =
+            await oracle.liquidityAccumulations(token.address);
+
+        expect(cumulativePrice, "Cumulative price").to.equal(fakePrice);
+        expect(cumulativeTokenLiquidity, "Cumulative token liquidity").to.equal(fakeTokenLiquidity);
+        expect(cumulativeQuoteTokenLiquidity, "Cumulative quote token liquidity").to.equal(fakeQuoteTokenLiquidity);
+        expect(cumulativePriceTimestamp, "Price accumulation timestamp").to.equal(fakeAccumulationTimestamp);
+        expect(cumulativeLiquidityTimestamp, "Liquidity accumulation timestamp").to.equal(fakeAccumulationTimestamp);
+    });
+
+    it("Shouldn't update observation timestamp or emit Updated when there's no price", async function () {
+        // Add liquidity
+        await addLiquidity(BigNumber.from(1000), BigNumber.from(1000));
+
+        const updateData = ethers.utils.hexZeroPad(token.address, 32);
+
+        // Update accumulators
+        await liquidityAccumulator.update(updateData);
+        await priceAccumulator.update(updateData);
+
+        const updateTx = await oracle.update(updateData);
+
+        // Shouldn't emite Updated since the oracle doesn't have enough info to calculate price
+        expect(updateTx).to.not.emit(oracle, "Updated");
+
+        const [, , , oTimestamp] = await oracle.observations(token.address);
+
+        // Observation timestamp should not update since the oracle doesn't have enough info to calculate price
+        expect(oTimestamp, "Observation timestamp").to.equal(0);
+
+        const [cumulativePrice, cumulativePriceTimestamp] = await oracle.priceAccumulations(token.address);
+        const [cumulativeTokenLiquidity, cumulativeQuoteTokenLiquidity, cumulativeLiquidityTimestamp] =
+            await oracle.liquidityAccumulations(token.address);
+
+        // Accumulation should update
+        expect(cumulativePrice, "Cumulative price").to.not.equal(0);
+        expect(cumulativeTokenLiquidity, "Cumulative token liquidity").to.not.equal(0);
+        expect(cumulativeQuoteTokenLiquidity, "Cumulative quote token liquidity").to.not.equal(0);
+        expect(cumulativePriceTimestamp, "Price accumulation timestamp").to.not.equal(0);
+        expect(cumulativeLiquidityTimestamp, "Liquidity accumulation timestamp").to.not.equal(0);
+    });
+
     it("Should revert if token == quoteToken", async function () {
         await expect(oracle.update(ethers.utils.hexZeroPad(quoteToken.address, 32))).to.be.reverted;
     });

--- a/test/price-accumulator/price-accumulator-test.js
+++ b/test/price-accumulator/price-accumulator-test.js
@@ -967,6 +967,16 @@ describe("PriceAccumulator#supportsInterface(interfaceId)", function () {
         const interfaceId = await interfaceIds.iQuoteToken();
         expect(await accumulator["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
     });
+
+    it("Should support IUpdateable", async () => {
+        const interfaceId = await interfaceIds.iUpdateable();
+        expect(await accumulator["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
+    });
+
+    it("Should support IAccumulator", async () => {
+        const interfaceId = await interfaceIds.iAccumulator();
+        expect(await accumulator["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
+    });
 });
 
 describe("PriceAccumulator#consultPrice(token)", function () {

--- a/test/price-accumulator/price-accumulator-test.js
+++ b/test/price-accumulator/price-accumulator-test.js
@@ -19,7 +19,7 @@ async function blockTimestamp(blockNum) {
     return (await ethers.provider.getBlock(blockNum)).timestamp;
 }
 
-describe("PriceAccumulator#getCurrentObservation", function () {
+describe("PriceAccumulator#fetchPrice", function () {
     const minUpdateDelay = 10000;
     const maxUpdateDelay = 30000;
 
@@ -44,10 +44,9 @@ describe("PriceAccumulator#getCurrentObservation", function () {
             // Configure price
             await accumulator.setPrice(GRT, test[0]);
 
-            const [price, timestamp] = await accumulator.getCurrentObservation(GRT);
+            const price = await accumulator.stubFetchPrice(GRT);
 
             expect(price).to.equal(test[0]);
-            expect(timestamp).to.equal(await currentBlockTimestamp());
         });
     }
 });
@@ -663,7 +662,7 @@ describe("PriceAccumulator#update", () => {
         const updateTime = (await ethers.provider.getBlock(receipt.blockNumber)).timestamp;
 
         const accumulation = await accumulator.getLastAccumulation(GRT);
-        const observation = await accumulator.getLastObservation(GRT);
+        const observation = await accumulator.observations(GRT);
 
         var expectedCumulativePrice = 0;
 
@@ -760,7 +759,7 @@ describe("PriceAccumulator#update", () => {
         const updateTime2 = (await ethers.provider.getBlock(receipt2.blockNumber)).timestamp;
 
         const accumulation2 = await accumulator.getLastAccumulation(GRT);
-        const observation2 = await accumulator.getLastObservation(GRT);
+        const observation2 = await accumulator.observations(GRT);
 
         const deltaTime2 = updateTime2 - updateTime;
 
@@ -894,7 +893,7 @@ describe("PriceAccumulator#update", () => {
             const expectedCumulativePrice = initialPrice.mul(BigNumber.from(deltaTime));
 
             const accumulation = await accumulator.getLastAccumulation(GRT);
-            const observation = await accumulator.getLastObservation(GRT);
+            const observation = await accumulator.observations(GRT);
 
             expect(accumulation["cumulativePrice"], "CTL").to.equal(expectedCumulativePrice);
 
@@ -931,7 +930,7 @@ describe("PriceAccumulator#update", () => {
         await expect(firstUpdateReceipt).to.not.emit(accumulator, "Updated");
 
         const accumulation = await accumulator.getLastAccumulation(GRT);
-        const observation = await accumulator.getLastObservation(GRT);
+        const observation = await accumulator.observations(GRT);
 
         expect(accumulation["cumulativePrice"]).to.equal(0);
         expect(observation["price"]).to.equal(initialPrice);

--- a/test/price-accumulator/price-accumulator-test.js
+++ b/test/price-accumulator/price-accumulator-test.js
@@ -87,6 +87,9 @@ describe("PriceAccumulator#needsUpdate", () => {
         // Override changeThresholdPassed (false)
         await accumulator.overrideChangeThresholdPassed(true, false);
 
+        // Override validateObservation
+        await accumulator.overrideValidateObservation(true, true);
+
         // Time increases by 1 second with each block mined
         await hre.timeAndMine.setTimeIncrease(1);
 
@@ -890,7 +893,7 @@ describe("PriceAccumulator#update", () => {
 
             const deltaTime = firstUpdateTime - initialUpdateTime;
 
-            const expectedCumulativePrice = initialPrice.mul(BigNumber.from(deltaTime));
+            const expectedCumulativePrice = initialPrice.add(initialPrice.mul(BigNumber.from(deltaTime)));
 
             const accumulation = await accumulator.getLastAccumulation(GRT);
             const observation = await accumulator.observations(GRT);
@@ -932,7 +935,7 @@ describe("PriceAccumulator#update", () => {
         const accumulation = await accumulator.getLastAccumulation(GRT);
         const observation = await accumulator.observations(GRT);
 
-        expect(accumulation["cumulativePrice"]).to.equal(0);
+        expect(accumulation["cumulativePrice"]).to.equal(initialPrice);
         expect(observation["price"]).to.equal(initialPrice);
         expect(observation["timestamp"]).to.equal(initialUpdateTime);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,6 +31,11 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@ensdomains/ens@^0.4.4":
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/@ensdomains/ens/-/ens-0.4.5.tgz#e0aebc005afdc066447c6e22feb4eda89a5edbfc"
@@ -2279,7 +2284,7 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2404,6 +2409,15 @@ cli-table3@^0.5.0:
     string-width "^2.1.1"
   optionalDependencies:
     colors "^1.1.2"
+
+cli-table3@^0.6.0:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.2.tgz#aaf5df9d8b5bf12634dc8b3040806a0c07120d2a"
+  integrity sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
 
 cli-width@^2.0.0:
   version "2.2.1"
@@ -4552,6 +4566,14 @@ har-validator@~5.1.3:
   dependencies:
     ajv "^6.12.3"
     har-schema "^2.0.0"
+
+hardhat-contract-sizer@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/hardhat-contract-sizer/-/hardhat-contract-sizer-2.5.1.tgz#cb0b8dd32593b7a28c8d96ecde04841292bbd603"
+  integrity sha512-28yRb73e30aBVaZOOHTlHZFIdIasA/iFunIehrUviIJTubvdQjtSiQUo2wexHFtt71mQeMPP8qjw2sdbgatDnQ==
+  dependencies:
+    chalk "^4.0.0"
+    cli-table3 "^0.6.0"
 
 hardhat-gas-reporter@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
### Interfaces
- Add IUpdateable#lastUpdateTime and IUpdateable#timeSinceLastUpdate
- Add IAccumulator to define common functions
- Remove `getLastObservation` and `getCurrentObservation` from accumulators

### Accumulators
- Initialize accumulators when initializing instead of just the observation
- Validate all observations instead of only the ones after the first update
- Add AbstractAccumulator to define common logic and reduce redundancy
- Add convenience functions: `changeThresholdSurpassed(address token, uint256 changeThreshold)` and `updateThresholdSurpassed(address token)`
- Make consultations use stored observations by default, rather than returning data directly from the source
  - A `maxAge` of 0 allows for the consultation to return data directly from the source

### Oracles
- Make PeriodicAccumulationOracle only update observation timestamp and emit Updated when it has enough information to calculate a price

### Libraries
 - Remove unused UniswapV2PriceAccumulator data structure