### PR TITLE
Release/v1.0.0 rc.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v1.0.0-rc.9
+### Interfaces
+- Change the spec of oracle consultations where using a max age of 0 will return data as of the latest block, straight from the source
+
+### Oracles
+- Improve price calculation precision of AggregatedOracle
+- Add PeriodicAccumulationOracle#canUpdate that returns false when one or both of the accumulators are uninitialized
+- Make PeriodicAccumulationOracle#update return true only if something was updated
+- Update AggregatedOracle and PeriodicAccumulation oracle to conform to the new oracle spec
+
+### Accumulators
+- Improve price calculation precision of UniswapV3PriceAccumulator
+- Add observation validation logs
+
 ## v1.0.0-rc.8
 ### Interfaces
 - Add IUpdateable#lastUpdateTime and IUpdateable#timeSinceLastUpdate

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pythia Core
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-![637 out of 637 tests passing](https://img.shields.io/badge/tests-637/637%20passing-brightgreen.svg?style=flat-square)
+![641 out of 641 tests passing](https://img.shields.io/badge/tests-641/641%20passing-brightgreen.svg?style=flat-square)
 ![test-coverage 100%](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg?style=flat-square)
 
 Pythia Core is a set of Solidity smart contracts for building EVM oracle solutions.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pythia Core
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-![620 out of 620 tests passing](https://img.shields.io/badge/tests-620/620%20passing-brightgreen.svg?style=flat-square)
+![637 out of 637 tests passing](https://img.shields.io/badge/tests-637/637%20passing-brightgreen.svg?style=flat-square)
 ![test-coverage 100%](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg?style=flat-square)
 
 Pythia Core is a set of Solidity smart contracts for building EVM oracle solutions.

--- a/contracts/interfaces/ILiquidityOracle.sol
+++ b/contracts/interfaces/ILiquidityOracle.sol
@@ -23,8 +23,10 @@ abstract contract ILiquidityOracle is IUpdateable, IQuoteToken {
     /**
      * @notice Gets the liquidity levels of the token and the quote token in the underlying pool, reverting if the
      *  quotation is older than the maximum allowable age.
+     * @dev Using maxAge of 0 can be gas costly and the returned data is easier to manipulate.
      * @param token The token to get liquidity levels of (along with the quote token).
-     * @param maxAge The maximum age of the quotation, in seconds.
+     * @param maxAge The maximum age of the quotation, in seconds. If 0, the function gets the instant rates as of the
+     *   latest block, straight from the source.
      * @return tokenLiquidity The amount of the token that is liquid in the underlying pool, in wei.
      * @return quoteTokenLiquidity The amount of the quote token that is liquid in the underlying pool, in wei.
      */

--- a/contracts/interfaces/IOracle.sol
+++ b/contracts/interfaces/IOracle.sol
@@ -45,8 +45,10 @@ abstract contract IOracle is IUpdateable, IPriceOracle, ILiquidityOracle {
     /**
      * @notice Gets the price of a token in terms of the quote token along with the liquidity levels of the token and
      *  quote token in the underlying pool, reverting if the quotation is older than the maximum allowable age.
+     * @dev Using maxAge of 0 can be gas costly and the returned data is easier to manipulate.
      * @param token The token to get the price of.
-     * @param maxAge The maximum age of the quotation, in seconds.
+     * @param maxAge The maximum age of the quotation, in seconds. If 0, the function gets the instant rates as of the
+     *   latest block, straight from the source.
      * @return price The quote token denominated price for a whole token.
      * @return tokenLiquidity The amount of the token that is liquid in the underlying pool, in wei.
      * @return quoteTokenLiquidity The amount of the quote token that is liquid in the underlying pool, in wei.

--- a/contracts/interfaces/IPriceOracle.sol
+++ b/contracts/interfaces/IPriceOracle.sol
@@ -17,8 +17,10 @@ abstract contract IPriceOracle is IUpdateable, IQuoteToken {
     /**
      * @notice Gets the price of a token in terms of the quote token, reverting if the quotation is older than the
      *  maximum allowable age.
+     * @dev Using maxAge of 0 can be gas costly and the returned data is easier to manipulate.
      * @param token The token to get the price of.
-     * @param maxAge The maximum age of the quotation, in seconds.
+     * @param maxAge The maximum age of the quotation, in seconds. If 0, the function gets the instant rates as of the
+     *   latest block, straight from the source.
      * @return price The quote token denominated price for a whole token.
      */
     function consultPrice(address token, uint256 maxAge) public view virtual returns (uint112 price);

--- a/contracts/oracles/AggregatedOracle.sol
+++ b/contracts/oracles/AggregatedOracle.sol
@@ -157,7 +157,7 @@ contract AggregatedOracle is IAggregatedOracle, PeriodicOracle, ExplicitQuotatio
             }
         }
 
-        (, , , uint256 validResponses) = aggregateUnderlying(token);
+        (, , , uint256 validResponses) = aggregateUnderlying(token, calculateMaxAge());
 
         // Only return true if we have reached the minimum number of valid underlying oracle consultations
         return validResponses >= 1;
@@ -196,7 +196,7 @@ contract AggregatedOracle is IAggregatedOracle, PeriodicOracle, ExplicitQuotatio
         uint256 quoteTokenLiquidity;
         uint256 validResponses;
 
-        (price, tokenLiquidity, quoteTokenLiquidity, validResponses) = aggregateUnderlying(token);
+        (price, tokenLiquidity, quoteTokenLiquidity, validResponses) = aggregateUnderlying(token, calculateMaxAge());
 
         // Liquidities should rarely ever overflow uint112 (if ever), but if they do, we set the observation to the max
         // This allows the price to continue to be updated while tightly packing liquidities for gas efficiency
@@ -229,7 +229,7 @@ contract AggregatedOracle is IAggregatedOracle, PeriodicOracle, ExplicitQuotatio
         return period - 1; // Subract 1 to ensure that we don't use any data from the previous period
     }
 
-    function aggregateUnderlying(address token)
+    function aggregateUnderlying(address token, uint256 maxAge)
         internal
         view
         returns (
@@ -240,8 +240,6 @@ contract AggregatedOracle is IAggregatedOracle, PeriodicOracle, ExplicitQuotatio
         )
     {
         uint256 qtDecimals = quoteTokenDecimals();
-
-        uint256 maxAge = calculateMaxAge();
 
         uint256 denominator; // sum of oracleQuoteTokenLiquidity divided by oraclePrice
 

--- a/contracts/oracles/PeriodicAccumulationOracle.sol
+++ b/contracts/oracles/PeriodicAccumulationOracle.sol
@@ -74,6 +74,7 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
 
         bool updatedObservation;
         bool missingPrice;
+        bool anythingUpdated;
 
         /*
          * 1. Update price
@@ -107,6 +108,8 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
 
                 lastAccumulation.cumulativePrice = freshAccumulation.cumulativePrice;
                 lastAccumulation.timestamp = freshAccumulation.timestamp;
+
+                anythingUpdated = true;
             }
         }
 
@@ -138,6 +141,8 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
                 lastAccumulation.cumulativeTokenLiquidity = freshAccumulation.cumulativeTokenLiquidity;
                 lastAccumulation.cumulativeQuoteTokenLiquidity = freshAccumulation.cumulativeQuoteTokenLiquidity;
                 lastAccumulation.timestamp = freshAccumulation.timestamp;
+
+                anythingUpdated = true;
             }
         }
 
@@ -156,7 +161,7 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
             );
         }
 
-        return true;
+        return anythingUpdated;
     }
 
     /// @inheritdoc AbstractOracle

--- a/contracts/oracles/PeriodicAccumulationOracle.sol
+++ b/contracts/oracles/PeriodicAccumulationOracle.sol
@@ -143,4 +143,21 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
 
         return true;
     }
+
+    /// @inheritdoc AbstractOracle
+    function instantFetch(address token)
+        internal
+        view
+        virtual
+        override
+        returns (
+            uint112 price,
+            uint112 tokenLiquidity,
+            uint112 quoteTokenLiquidity
+        )
+    {
+        // We assume the accumulators are also oracles... the interfaces need to be refactored
+        price = IPriceOracle(priceAccumulator).consultPrice(token, 0);
+        (tokenLiquidity, quoteTokenLiquidity) = ILiquidityOracle(liquidityAccumulator).consultLiquidity(token, 0);
+    }
 }

--- a/contracts/oracles/PeriodicAccumulationOracle.sol
+++ b/contracts/oracles/PeriodicAccumulationOracle.sol
@@ -32,6 +32,21 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
         priceAccumulator = priceAccumulator_;
     }
 
+    /// @inheritdoc PeriodicOracle
+    function canUpdate(bytes memory data) public view virtual override returns (bool) {
+        address token = abi.decode(data, (address));
+
+        if (
+            ILiquidityAccumulator(liquidityAccumulator).getLastAccumulation(token).timestamp == 0 ||
+            IPriceAccumulator(priceAccumulator).getLastAccumulation(token).timestamp == 0
+        ) {
+            // Can't update if the accumulators haven't been initialized
+            return false;
+        }
+
+        return super.canUpdate(data);
+    }
+
     /// @inheritdoc AbstractOracle
     function lastUpdateTime(bytes memory data) public view virtual override returns (uint256) {
         address token = abi.decode(data, (address));

--- a/contracts/test/accumulators/LiquidityAccumulatorStub.sol
+++ b/contracts/test/accumulators/LiquidityAccumulatorStub.sol
@@ -55,6 +55,19 @@ contract LiquidityAccumulatorStub is LiquidityAccumulator {
         observation.timestamp = timestamp;
     }
 
+    function stubSetAccumulation(
+        address token,
+        uint112 cumulativeTokenLiquidity,
+        uint112 cumulativeQuoteTokenLiquidity,
+        uint32 timestamp
+    ) public {
+        AccumulationLibrary.LiquidityAccumulator storage accumulation = accumulations[token];
+
+        accumulation.cumulativeTokenLiquidity = cumulativeTokenLiquidity;
+        accumulation.cumulativeQuoteTokenLiquidity = cumulativeQuoteTokenLiquidity;
+        accumulation.timestamp = timestamp;
+    }
+
     function overrideChangeThresholdPassed(bool overridden, bool changeThresholdPassed) public {
         config.changeThresholdOverridden = overridden;
         config.changeThresholdPassed = changeThresholdPassed;

--- a/contracts/test/accumulators/LiquidityAccumulatorStub.sol
+++ b/contracts/test/accumulators/LiquidityAccumulatorStub.sol
@@ -16,6 +16,7 @@ contract LiquidityAccumulatorStub is LiquidityAccumulator {
         bool needsUpdate;
         bool validateObservationOverridden;
         bool validateObservation;
+        bool useLastAccumulationAsCurrent;
     }
 
     mapping(address => MockLiquidity) public mockLiquidity;
@@ -83,6 +84,10 @@ contract LiquidityAccumulatorStub is LiquidityAccumulator {
         config.validateObservation = validateObservation_;
     }
 
+    function overrideCurrentAccumulation(bool useLastAccumulationAsCurrent) public {
+        config.useLastAccumulationAsCurrent = useLastAccumulationAsCurrent;
+    }
+
     function stubValidateObservation(
         bytes memory updateData,
         uint112 tokenLiquidity,
@@ -142,6 +147,17 @@ contract LiquidityAccumulatorStub is LiquidityAccumulator {
     ) internal view virtual override returns (bool) {
         if (config.changeThresholdOverridden) return config.changeThresholdPassed;
         else return super.changeThresholdSurpassed(a, b, updateThreshold);
+    }
+
+    function getCurrentAccumulation(address token)
+        public
+        view
+        virtual
+        override
+        returns (AccumulationLibrary.LiquidityAccumulator memory accumulation)
+    {
+        if (config.useLastAccumulationAsCurrent) return getLastAccumulation(token);
+        else return super.getCurrentAccumulation(token);
     }
 }
 

--- a/contracts/test/accumulators/PriceAccumulatorStub.sol
+++ b/contracts/test/accumulators/PriceAccumulatorStub.sol
@@ -11,6 +11,7 @@ contract PriceAccumulatorStub is PriceAccumulator {
         bool needsUpdate;
         bool validateObservationOverridden;
         bool validateObservation;
+        bool useLastAccumulationAsCurrent;
     }
 
     mapping(address => uint112) public mockPrices;
@@ -67,6 +68,10 @@ contract PriceAccumulatorStub is PriceAccumulator {
         config.validateObservation = validateObservation_;
     }
 
+    function overrideCurrentAccumulation(bool useLastAccumulationAsCurrent) public {
+        config.useLastAccumulationAsCurrent = useLastAccumulationAsCurrent;
+    }
+
     function stubFetchPrice(address token) public view returns (uint256 price) {
         return fetchPrice(token);
     }
@@ -106,6 +111,17 @@ contract PriceAccumulatorStub is PriceAccumulator {
     ) internal view virtual override returns (bool) {
         if (config.changeThresholdOverridden) return config.changeThresholdPassed;
         else return super.changeThresholdSurpassed(a, b, updateThreshold);
+    }
+
+    function getCurrentAccumulation(address token)
+        public
+        view
+        virtual
+        override
+        returns (AccumulationLibrary.PriceAccumulator memory accumulation)
+    {
+        if (config.useLastAccumulationAsCurrent) return getLastAccumulation(token);
+        else return super.getCurrentAccumulation(token);
     }
 }
 

--- a/contracts/test/accumulators/PriceAccumulatorStub.sol
+++ b/contracts/test/accumulators/PriceAccumulatorStub.sol
@@ -41,6 +41,17 @@ contract PriceAccumulatorStub is PriceAccumulator {
         observation.timestamp = timestamp;
     }
 
+    function stubSetAccumulation(
+        address token,
+        uint112 cumulativePrice,
+        uint32 timestamp
+    ) public {
+        AccumulationLibrary.PriceAccumulator storage accumulation = accumulations[token];
+
+        accumulation.cumulativePrice = cumulativePrice;
+        accumulation.timestamp = timestamp;
+    }
+
     function overrideChangeThresholdPassed(bool overridden, bool changeThresholdPassed) public {
         config.changeThresholdOverridden = overridden;
         config.changeThresholdPassed = changeThresholdPassed;

--- a/contracts/test/oracles/MockOracle.sol
+++ b/contracts/test/oracles/MockOracle.sol
@@ -13,6 +13,8 @@ contract MockOracle is AbstractOracle {
     bool _updateError;
     bool _updateErrorWithReason;
 
+    mapping(address => ObservationLibrary.Observation) instantRates;
+
     constructor(address quoteToken_) AbstractOracle(quoteToken_) {}
 
     function stubSetObservation(
@@ -28,6 +30,19 @@ contract MockOracle is AbstractOracle {
         observation.tokenLiquidity = tokenLiquidity;
         observation.quoteTokenLiquidity = quoteTokenLiquidity;
         observation.timestamp = timestamp;
+    }
+
+    function stubSetInstantRates(
+        address token,
+        uint112 price,
+        uint112 tokenLiquidity,
+        uint112 quoteTokenLiquidity
+    ) public {
+        ObservationLibrary.Observation storage observation = instantRates[token];
+
+        observation.price = price;
+        observation.tokenLiquidity = tokenLiquidity;
+        observation.quoteTokenLiquidity = quoteTokenLiquidity;
     }
 
     function stubSetNeedsUpdate(bool b) public {
@@ -102,5 +117,23 @@ contract MockOracle is AbstractOracle {
 
     function canUpdate(bytes memory data) public view virtual override returns (bool) {
         return needsUpdate(data);
+    }
+
+    function instantFetch(address token)
+        internal
+        view
+        virtual
+        override
+        returns (
+            uint112 price,
+            uint112 tokenLiquidity,
+            uint112 quoteTokenLiquidity
+        )
+    {
+        ObservationLibrary.Observation storage observation = instantRates[token];
+
+        price = observation.price;
+        tokenLiquidity = observation.tokenLiquidity;
+        quoteTokenLiquidity = observation.quoteTokenLiquidity;
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythia-oracle/pythia-core",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "main": "index.js",
   "author": "TRILEZ SOFTWARE INC.",
   "license": "MIT",

--- a/test/liquidity-accumulator/liquidity-accumulator-test.js
+++ b/test/liquidity-accumulator/liquidity-accumulator-test.js
@@ -1543,6 +1543,22 @@ describe("LiquidityAccumulator#validateObservation(token, tokenLiquidity, quoteT
             expect(
                 await accumulator.callStatic.stubValidateObservation(updateData, oTokenLiquidity, oQuoteTokenLiquidity)
             ).to.equal(true);
+
+            const tx = await accumulator.stubValidateObservation(updateData, oTokenLiquidity, oQuoteTokenLiquidity);
+            const receipt = await tx.wait();
+            const timestamp = await blockTimestamp(receipt.blockNumber);
+
+            await expect(tx)
+                .to.emit(accumulator, "ValidationPerformed")
+                .withArgs(
+                    token.address,
+                    oTokenLiquidity,
+                    oQuoteTokenLiquidity,
+                    pTokenLiquidity,
+                    pQuoteTokenLiquidity,
+                    timestamp,
+                    true
+                );
         });
 
         it("Should return false when the observed token liquidity is too different from the provided value", async function () {
@@ -1562,6 +1578,22 @@ describe("LiquidityAccumulator#validateObservation(token, tokenLiquidity, quoteT
             expect(
                 await accumulator.callStatic.stubValidateObservation(updateData, oTokenLiquidity, oQuoteTokenLiquidity)
             ).to.equal(false);
+
+            const tx = await accumulator.stubValidateObservation(updateData, oTokenLiquidity, oQuoteTokenLiquidity);
+            const receipt = await tx.wait();
+            const timestamp = await blockTimestamp(receipt.blockNumber);
+
+            await expect(tx)
+                .to.emit(accumulator, "ValidationPerformed")
+                .withArgs(
+                    token.address,
+                    oTokenLiquidity,
+                    oQuoteTokenLiquidity,
+                    pTokenLiquidity,
+                    pQuoteTokenLiquidity,
+                    timestamp,
+                    false
+                );
         });
 
         it("Should return false when the observed quote token liquidity is too different from the provided value", async function () {
@@ -1581,6 +1613,22 @@ describe("LiquidityAccumulator#validateObservation(token, tokenLiquidity, quoteT
             expect(
                 await accumulator.callStatic.stubValidateObservation(updateData, oTokenLiquidity, oQuoteTokenLiquidity)
             ).to.equal(false);
+
+            const tx = await accumulator.stubValidateObservation(updateData, oTokenLiquidity, oQuoteTokenLiquidity);
+            const receipt = await tx.wait();
+            const timestamp = await blockTimestamp(receipt.blockNumber);
+
+            await expect(tx)
+                .to.emit(accumulator, "ValidationPerformed")
+                .withArgs(
+                    token.address,
+                    oTokenLiquidity,
+                    oQuoteTokenLiquidity,
+                    pTokenLiquidity,
+                    pQuoteTokenLiquidity,
+                    timestamp,
+                    false
+                );
         });
 
         it("Should return false when the observed liquidity levels are too different from the provided values", async function () {
@@ -1600,6 +1648,22 @@ describe("LiquidityAccumulator#validateObservation(token, tokenLiquidity, quoteT
             expect(
                 await accumulator.callStatic.stubValidateObservation(updateData, oTokenLiquidity, oQuoteTokenLiquidity)
             ).to.equal(false);
+
+            const tx = await accumulator.stubValidateObservation(updateData, oTokenLiquidity, oQuoteTokenLiquidity);
+            const receipt = await tx.wait();
+            const timestamp = await blockTimestamp(receipt.blockNumber);
+
+            await expect(tx)
+                .to.emit(accumulator, "ValidationPerformed")
+                .withArgs(
+                    token.address,
+                    oTokenLiquidity,
+                    oQuoteTokenLiquidity,
+                    pTokenLiquidity,
+                    pQuoteTokenLiquidity,
+                    timestamp,
+                    false
+                );
         });
     });
 });

--- a/test/oracles/aggregated-oracle.js
+++ b/test/oracles/aggregated-oracle.js
@@ -1375,9 +1375,6 @@ describe("AggregatedOracle#update w/ 2 underlying oracle", function () {
         const totalTokenLiquidity = BigNumber.from(2).pow(112).sub(1);
         const totalQuoteTokenLiquidity = BigNumber.from(2).pow(112).sub(1);
 
-        // Slight loss of precision from the harmonic mean calculation, but this is okay (it's negligible)
-        price = BigNumber.from("1000000000000000121");
-
         await expect(oracle.update(ethers.utils.hexZeroPad(token, 32)), "Update log")
             .to.emit(oracle, "Updated")
             .withArgs(token, price, totalTokenLiquidity, totalQuoteTokenLiquidity, timestamp);

--- a/test/oracles/aggregated-oracle.js
+++ b/test/oracles/aggregated-oracle.js
@@ -317,6 +317,31 @@ describe("AggregatedOracle#consultPrice(token)", function () {
     });
 });
 
+describe("AggregatedOracle#consultPrice(token, maxAge = 0)", function () {
+    var underlyingOracle;
+    var oracle;
+
+    beforeEach(async () => {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("AggregatedOracle");
+
+        underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        oracle = await oracleFactory.deploy("NAME", USDC, "NIL", 6, [underlyingOracle.address], [], PERIOD);
+    });
+
+    it("Should get the set price (=1)", async () => {
+        const price = BigNumber.from(1);
+        const tokenLiqudity = BigNumber.from(2);
+        const quoteTokenLiquidity = BigNumber.from(3);
+
+        await underlyingOracle.stubSetInstantRates(AddressZero, price, tokenLiqudity, quoteTokenLiquidity);
+
+        expect(await oracle["consultPrice(address,uint256)"](AddressZero, 0)).to.equal(price);
+    });
+});
+
 describe("AggregatedOracle#consultPrice(token, maxAge)", function () {
     const MAX_AGE = 60;
 
@@ -496,6 +521,34 @@ describe("AggregatedOracle#consultLiquidity(token)", function () {
             expect(tokenLiqudity).to.equal(_tokenLiqudity);
             expect(quoteTokenLiquidity).to.equal(_quoteTokenLiquidity);
         });
+    });
+});
+
+describe("AggregatedOracle#consultLiquidity(token, maxAge = 0)", function () {
+    var underlyingOracle;
+    var oracle;
+
+    beforeEach(async () => {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("AggregatedOracle");
+
+        underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        oracle = await oracleFactory.deploy("NAME", USDC, "NIL", 6, [underlyingOracle.address], [], PERIOD);
+    });
+
+    it("Should get the set price (=1)", async () => {
+        const price = BigNumber.from(1);
+        const tokenLiqudity = BigNumber.from(2);
+        const quoteTokenLiquidity = BigNumber.from(3);
+
+        await underlyingOracle.stubSetInstantRates(AddressZero, price, tokenLiqudity, quoteTokenLiquidity);
+
+        const liquitity = await oracle["consultLiquidity(address,uint256)"](AddressZero, 0);
+
+        expect(liquitity["tokenLiquidity"]).to.equal(tokenLiqudity);
+        expect(liquitity["quoteTokenLiquidity"]).to.equal(quoteTokenLiquidity);
     });
 });
 
@@ -743,6 +796,156 @@ describe("AggregatedOracle#consult(token)", function () {
             expect(tokenLiqudity).to.equal(_tokenLiqudity);
             expect(quoteTokenLiquidity).to.equal(_quoteTokenLiquidity);
         });
+    });
+});
+
+describe("AggregatedOracle#consult(token, maxAge = 0)", function () {
+    var oracleFactory;
+    var mockOracleFactory;
+    var underlyingOracle;
+    var oracle;
+
+    beforeEach(async () => {
+        mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        oracleFactory = await ethers.getContractFactory("AggregatedOracle");
+
+        underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        oracle = await oracleFactory.deploy("NAME", USDC, "NIL", 6, [underlyingOracle.address], [], PERIOD);
+    });
+
+    it("Should get the set price (=1)", async () => {
+        const price = BigNumber.from(1);
+        const tokenLiqudity = BigNumber.from(2);
+        const quoteTokenLiquidity = BigNumber.from(3);
+
+        await underlyingOracle.stubSetInstantRates(AddressZero, price, tokenLiqudity, quoteTokenLiquidity);
+
+        const consultation = await oracle["consult(address,uint256)"](AddressZero, 0);
+
+        expect(consultation["price"]).to.equal(price);
+        expect(consultation["tokenLiquidity"]).to.equal(tokenLiqudity);
+        expect(consultation["quoteTokenLiquidity"]).to.equal(quoteTokenLiquidity);
+    });
+
+    it("Should revert when there are no valid responses", async function () {
+        await underlyingOracle.stubSetConsultError(true);
+
+        await expect(oracle["consult(address,uint256)"](AddressZero, 0)).to.be.revertedWith(
+            "AggregatedOracle: INVALID_NUM_CONSULTATIONS"
+        );
+    });
+
+    it("Should revert when the price exceeds uint112.max", async function () {
+        // Redeploy with more quote token decimal places
+        oracle = await oracleFactory.deploy("NAME", USDC, "NIL", 18, [underlyingOracle.address], [], PERIOD);
+
+        const price = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+        const tokenLiqudity = BigNumber.from(2);
+        const quoteTokenLiquidity = BigNumber.from(3);
+
+        await underlyingOracle.stubSetInstantRates(AddressZero, price, tokenLiqudity, quoteTokenLiquidity);
+
+        await expect(oracle["consult(address,uint256)"](AddressZero, 0)).to.be.revertedWith(
+            "AggregatedOracle: PRICE_TOO_HIGH"
+        );
+    });
+
+    it("Should report token liquidity of uint112.max when it exceeds that", async function () {
+        const underlyingOracle2 = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle2.deployed();
+
+        // Redeploy with additional underlying oracle
+        oracle = await oracleFactory.deploy(
+            "NAME",
+            USDC,
+            "NIL",
+            6,
+            [underlyingOracle.address, underlyingOracle2.address],
+            [],
+            PERIOD
+        );
+
+        const price = BigNumber.from(1);
+        const tokenLiqudity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+        const quoteTokenLiquidity = BigNumber.from(1);
+
+        await underlyingOracle.stubSetInstantRates(AddressZero, price, tokenLiqudity, quoteTokenLiquidity);
+        await underlyingOracle2.stubSetInstantRates(AddressZero, price, tokenLiqudity, quoteTokenLiquidity);
+
+        const totalTokenLiquidity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+        const totalQuoteTokenLiquidity = quoteTokenLiquidity.mul(2);
+
+        const consultation = await oracle["consult(address,uint256)"](AddressZero, 0);
+
+        expect(consultation["price"]).to.equal(price);
+        expect(consultation["tokenLiquidity"]).to.equal(totalTokenLiquidity);
+        expect(consultation["quoteTokenLiquidity"]).to.equal(totalQuoteTokenLiquidity);
+    });
+
+    it("Should report quote token liquidity of uint112.max when it exceeds that", async function () {
+        const underlyingOracle2 = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle2.deployed();
+
+        // Redeploy with additional underlying oracle
+        oracle = await oracleFactory.deploy(
+            "NAME",
+            USDC,
+            "NIL",
+            6,
+            [underlyingOracle.address, underlyingOracle2.address],
+            [],
+            PERIOD
+        );
+
+        const price = BigNumber.from(1);
+        const tokenLiqudity = BigNumber.from(1);
+        const quoteTokenLiquidity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+
+        await underlyingOracle.stubSetInstantRates(AddressZero, price, tokenLiqudity, quoteTokenLiquidity);
+        await underlyingOracle2.stubSetInstantRates(AddressZero, price, tokenLiqudity, quoteTokenLiquidity);
+
+        const totalTokenLiquidity = tokenLiqudity.mul(2);
+        const totalQuoteTokenLiquidity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+
+        const consultation = await oracle["consult(address,uint256)"](AddressZero, 0);
+
+        expect(consultation["price"]).to.equal(price);
+        expect(consultation["tokenLiquidity"]).to.equal(totalTokenLiquidity);
+        expect(consultation["quoteTokenLiquidity"]).to.equal(totalQuoteTokenLiquidity);
+    });
+
+    it("Should report liquidities of uint112.max when they exceeds that", async function () {
+        const underlyingOracle2 = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle2.deployed();
+
+        // Redeploy with additional underlying oracle
+        oracle = await oracleFactory.deploy(
+            "NAME",
+            USDC,
+            "NIL",
+            6,
+            [underlyingOracle.address, underlyingOracle2.address],
+            [],
+            PERIOD
+        );
+
+        const price = BigNumber.from(1);
+        const tokenLiqudity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+        const quoteTokenLiquidity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+
+        await underlyingOracle.stubSetInstantRates(AddressZero, price, tokenLiqudity, quoteTokenLiquidity);
+        await underlyingOracle2.stubSetInstantRates(AddressZero, price, tokenLiqudity, quoteTokenLiquidity);
+
+        const totalTokenLiquidity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+        const totalQuoteTokenLiquidity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+
+        const consultation = await oracle["consult(address,uint256)"](AddressZero, 0);
+
+        expect(consultation["price"]).to.equal(price);
+        expect(consultation["tokenLiquidity"]).to.equal(totalTokenLiquidity);
+        expect(consultation["quoteTokenLiquidity"]).to.equal(totalQuoteTokenLiquidity);
     });
 });
 

--- a/test/oracles/periodic-accumulation-oracle.js
+++ b/test/oracles/periodic-accumulation-oracle.js
@@ -927,7 +927,7 @@ describe("PeriodicAccumulationOracle#update", function () {
 
         const updateTx = await oracle.update(updateData);
 
-        expect(updateTx).to.not.emit(oracle, "Updated");
+        await expect(updateTx).to.not.emit(oracle, "Updated");
 
         const [oPrice, oTokenLiqudity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token.address);
 
@@ -960,7 +960,7 @@ describe("PeriodicAccumulationOracle#update", function () {
         const updateTx = await oracle.update(updateData);
 
         // Shouldn't emite Updated since the oracle doesn't have enough info to calculate price
-        expect(updateTx).to.not.emit(oracle, "Updated");
+        await expect(updateTx).to.not.emit(oracle, "Updated");
 
         const [, , , oTimestamp] = await oracle.observations(token.address);
 
@@ -1059,7 +1059,7 @@ describe("PeriodicAccumulationOracle#update", function () {
         }
 
         // Verify that the log matches the observation
-        expect(updateReceipt)
+        await expect(updateReceipt)
             .to.emit(oracle, "Updated")
             .withArgs(token.address, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
     };

--- a/test/oracles/periodic-accumulation-oracle.js
+++ b/test/oracles/periodic-accumulation-oracle.js
@@ -206,6 +206,41 @@ describe("PeriodicAccumulationOracle#consultPrice(token)", function () {
     });
 });
 
+describe("PeriodicAccumulationOracle#consultPrice(token, maxAge = 0)", function () {
+    const MIN_UPDATE_DELAY = 1;
+    const MAX_UPDATE_DELAY = 2;
+    const TWO_PERCENT_CHANGE = 2000000;
+
+    var priceAccumulator;
+    var liquidityAccumulator;
+    var oracle;
+
+    beforeEach(async () => {
+        const paFactory = await ethers.getContractFactory("PriceAccumulatorStub");
+        const laFactory = await ethers.getContractFactory("LiquidityAccumulatorStub");
+        const oracleFactory = await ethers.getContractFactory("PeriodicAccumulationOracle");
+
+        priceAccumulator = await paFactory.deploy(USDC, TWO_PERCENT_CHANGE, MIN_UPDATE_DELAY, MAX_UPDATE_DELAY);
+        liquidityAccumulator = await laFactory.deploy(USDC, TWO_PERCENT_CHANGE, MIN_UPDATE_DELAY, MAX_UPDATE_DELAY);
+
+        await priceAccumulator.deployed();
+        await liquidityAccumulator.deployed();
+
+        oracle = await oracleFactory.deploy(liquidityAccumulator.address, priceAccumulator.address, USDC, PERIOD);
+    });
+
+    it("Should get the set price (=1)", async () => {
+        const price = BigNumber.from(1);
+        const tokenLiquidity = BigNumber.from(1);
+        const quoteTokenLiquidity = BigNumber.from(1);
+
+        await priceAccumulator.setPrice(AddressZero, price);
+        await liquidityAccumulator.setLiquidity(AddressZero, tokenLiquidity, quoteTokenLiquidity);
+
+        expect(await oracle["consultPrice(address,uint256)"](AddressZero, 0)).to.equal(price);
+    });
+});
+
 describe("PeriodicAccumulationOracle#consultPrice(token, maxAge)", function () {
     const MAX_AGE = 60;
 
@@ -377,6 +412,44 @@ describe("PeriodicAccumulationOracle#consultLiquidity(token)", function () {
             expect(tokenLiqudity).to.equal(_tokenLiqudity);
             expect(quoteTokenLiquidity).to.equal(_quoteTokenLiquidity);
         });
+    });
+});
+
+describe("PeriodicAccumulationOracle#consultLiquidity(token, maxAge = 0)", function () {
+    const MIN_UPDATE_DELAY = 1;
+    const MAX_UPDATE_DELAY = 2;
+    const TWO_PERCENT_CHANGE = 2000000;
+
+    var priceAccumulator;
+    var liquidityAccumulator;
+    var oracle;
+
+    beforeEach(async () => {
+        const paFactory = await ethers.getContractFactory("PriceAccumulatorStub");
+        const laFactory = await ethers.getContractFactory("LiquidityAccumulatorStub");
+        const oracleFactory = await ethers.getContractFactory("PeriodicAccumulationOracle");
+
+        priceAccumulator = await paFactory.deploy(USDC, TWO_PERCENT_CHANGE, MIN_UPDATE_DELAY, MAX_UPDATE_DELAY);
+        liquidityAccumulator = await laFactory.deploy(USDC, TWO_PERCENT_CHANGE, MIN_UPDATE_DELAY, MAX_UPDATE_DELAY);
+
+        await priceAccumulator.deployed();
+        await liquidityAccumulator.deployed();
+
+        oracle = await oracleFactory.deploy(liquidityAccumulator.address, priceAccumulator.address, USDC, PERIOD);
+    });
+
+    it("Should get the set liquidities (2,3)", async () => {
+        const price = BigNumber.from(1);
+        const tokenLiquidity = BigNumber.from(2);
+        const quoteTokenLiquidity = BigNumber.from(3);
+
+        await priceAccumulator.setPrice(AddressZero, price);
+        await liquidityAccumulator.setLiquidity(AddressZero, tokenLiquidity, quoteTokenLiquidity);
+
+        const liquidity = await oracle["consultLiquidity(address,uint256)"](AddressZero, 0);
+
+        expect(liquidity["tokenLiquidity"]).to.equal(tokenLiquidity);
+        expect(liquidity["quoteTokenLiquidity"]).to.equal(quoteTokenLiquidity);
     });
 });
 
@@ -616,6 +689,45 @@ describe("PeriodicAccumulationOracle#consult(token)", function () {
             expect(tokenLiqudity).to.equal(_tokenLiqudity);
             expect(quoteTokenLiquidity).to.equal(_quoteTokenLiquidity);
         });
+    });
+});
+
+describe("PeriodicAccumulationOracle#consult(token, maxAge = 0)", function () {
+    const MIN_UPDATE_DELAY = 1;
+    const MAX_UPDATE_DELAY = 2;
+    const TWO_PERCENT_CHANGE = 2000000;
+
+    var priceAccumulator;
+    var liquidityAccumulator;
+    var oracle;
+
+    beforeEach(async () => {
+        const paFactory = await ethers.getContractFactory("PriceAccumulatorStub");
+        const laFactory = await ethers.getContractFactory("LiquidityAccumulatorStub");
+        const oracleFactory = await ethers.getContractFactory("PeriodicAccumulationOracle");
+
+        priceAccumulator = await paFactory.deploy(USDC, TWO_PERCENT_CHANGE, MIN_UPDATE_DELAY, MAX_UPDATE_DELAY);
+        liquidityAccumulator = await laFactory.deploy(USDC, TWO_PERCENT_CHANGE, MIN_UPDATE_DELAY, MAX_UPDATE_DELAY);
+
+        await priceAccumulator.deployed();
+        await liquidityAccumulator.deployed();
+
+        oracle = await oracleFactory.deploy(liquidityAccumulator.address, priceAccumulator.address, USDC, PERIOD);
+    });
+
+    it("Should get the set price (1) and liquidities (2,3)", async () => {
+        const price = BigNumber.from(1);
+        const tokenLiquidity = BigNumber.from(2);
+        const quoteTokenLiquidity = BigNumber.from(3);
+
+        await priceAccumulator.setPrice(AddressZero, price);
+        await liquidityAccumulator.setLiquidity(AddressZero, tokenLiquidity, quoteTokenLiquidity);
+
+        const consultation = await oracle["consult(address,uint256)"](AddressZero, 0);
+
+        expect(consultation["price"]).to.equal(price);
+        expect(consultation["tokenLiquidity"]).to.equal(tokenLiquidity);
+        expect(consultation["quoteTokenLiquidity"]).to.equal(quoteTokenLiquidity);
     });
 });
 

--- a/test/price-accumulator/price-accumulator-test.js
+++ b/test/price-accumulator/price-accumulator-test.js
@@ -1152,7 +1152,7 @@ describe("PriceAccumulator#consultPrice(token, maxAge = 60)", function () {
     });
 });
 
-describe("PriceAccumulator#validateObservation(token, tokenLiquidity, quoteTokenLiquidity)", function () {
+describe("PriceAccumulator#validateObservation(token, price)", function () {
     const minUpdateDelay = 10000;
     const maxUpdateDelay = 30000;
 
@@ -1191,6 +1191,14 @@ describe("PriceAccumulator#validateObservation(token, tokenLiquidity, quoteToken
             const updateData = ethers.utils.defaultAbiCoder.encode(["address", "uint"], [token.address, pPrice]);
 
             expect(await accumulator.callStatic.stubValidateObservation(updateData, oPrice)).to.equal(true);
+
+            const tx = await accumulator.stubValidateObservation(updateData, oPrice);
+            const receipt = await tx.wait();
+            const timestamp = await blockTimestamp(receipt.blockNumber);
+
+            await expect(tx)
+                .to.emit(accumulator, "ValidationPerformed")
+                .withArgs(token.address, oPrice, pPrice, timestamp, true);
         });
 
         it("Should return false when the observed price is too different from the provided value", async function () {
@@ -1203,6 +1211,14 @@ describe("PriceAccumulator#validateObservation(token, tokenLiquidity, quoteToken
             const updateData = ethers.utils.defaultAbiCoder.encode(["address", "uint"], [token.address, pPrice]);
 
             expect(await accumulator.callStatic.stubValidateObservation(updateData, oPrice)).to.equal(false);
+
+            const tx = await accumulator.stubValidateObservation(updateData, oPrice);
+            const receipt = await tx.wait();
+            const timestamp = await blockTimestamp(receipt.blockNumber);
+
+            await expect(tx)
+                .to.emit(accumulator, "ValidationPerformed")
+                .withArgs(token.address, oPrice, pPrice, timestamp, false);
         });
     });
 });


### PR DESCRIPTION
### Interfaces
- Change the spec of oracle consultations where using a max age of 0 will return data as of the latest block, straight from the source

### Oracles
- Improve price calculation precision of AggregatedOracle
- Add PeriodicAccumulationOracle#canUpdate that returns false when one or both of the accumulators are uninitialized
- Make PeriodicAccumulationOracle#update return true only if something was updated
- Update AggregatedOracle and PeriodicAccumulation oracle to conform to the new oracle spec

### Accumulators
- Improve price calculation precision of UniswapV3PriceAccumulator
- Add observation validation logs