### PR TITLE
Release/v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v2.0.0
+### Oracles
+- Change PeriodicAccumulationOracle freshness metric to use accumulator heartbeats
+- Add IOracle#liquidityDecimals
+- Make AggregatedOracle's minimum liquidity values operate with respect to its liquidity decimals
+- Bug fix: Make PeriodicAccumulationOracle discard old accumulations when updating to prevent older than desired time-weighted averages from being stored in oracle observations
+
+### Accumulators
+- Promote cumulative prices to uint224 from uint112
+- Parameterize and standardize liquidity decimals
+  - Rather than liquidity using the same number of decimals as the respective token, liquidity now uses the number of decimals specified in the constructor. Both the queried token and the quote token now always use the same number of decimal places.
+- Introduce geometric and harmonic time-weighted averages
+- Bug fix: time-weighted values are now calculated outside of unchecked blocks as overflow is not desired
+- Add IAccumulator#heartbeat
+
 ## v1.0.0
 ### Oracles
 - Require accumulators to be up-to-date when updating PeriodicAccumulationOracle

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Adrastia Core
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-![1310 out of 1310 tests passing](https://img.shields.io/badge/tests-1310/1310%20passing-brightgreen.svg?style=flat-square)
+![2904 out of 2904 tests passing](https://img.shields.io/badge/tests-2904/2904%20passing-brightgreen.svg?style=flat-square)
 ![test-coverage 100%](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg?style=flat-square)
 
 Adrastia Core is a set of Solidity smart contracts for building EVM oracle solutions.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Adrastia Core is a set of Solidity smart contracts for building EVM oracle solut
     - [Maintaining an oracle](#maintaining-an-oracle)
   - [Security](#security)
   - [Overview](#overview)
-    - [High level flow chart](#high-level-flow-chart)
+    - [High-level flow chart](#high-level-flow-chart)
     - [Accumulators](#accumulators)
     - [Oracles](#oracles)
   - [Limitations](#limitations)
@@ -35,7 +35,7 @@ Adrastia Core is a set of Solidity smart contracts for building EVM oracle solut
 
 ## Background
 
-To build reliaible decentralized financial applications, reliable price feeds are often needed. Since most, if not all, DeFi applications are fully automatic with large amounts of capital at stake, these price feeds must also have the highest degree of security and accuracy.
+To build reliable decentralized financial applications, reliable price feeds are often needed. Since most, if not all, DeFi applications are fully automatic with large amounts of capital at stake, these price feeds must also have the highest degree of security and accuracy.
 
 The current standard in DeFi is to use trusted and centralized price oracle solutions that push off-chain data on-chain, which has its risks. These risks relate to:
 - Centralized exchanges risks
@@ -44,7 +44,7 @@ The current standard in DeFi is to use trusted and centralized price oracle solu
   - Bugs
   - Accuracy and integrity of the closed source systems
 - Data source reliability, accuracy, and availability
-- Bug-free code to read from these sources and post on-chain with all intermediate calculations for each and every price reporter (of which may be closed source)
+- Bug-free code to read from these sources and post on-chain with all intermediate calculations for each price reporter (of which may be closed source)
 - Price reporters must not collude to report inaccurate prices
 - Price reporters must maintain the highest level of physical and digital security to protect their code and keys from attacks
 
@@ -57,9 +57,9 @@ Adrastia is designed to mitigate these risks by keeping everything on-chain - pr
 - Rigorous and thorough testing with 100% test coverage
 - And more
 
-Furthermore, while it's still possible to manipulate on-chain prices, the presence of arbitrageurs, MEV, and regular users makes doing so incredibly costly. The further use of TWAPs (time-weighted average prices) increases the cost exponentially by allowing arbitrageurs time to move funds between exchanges and profit greatly from trading. Please read [this related paper](https://github.com/adrastia-oracle/uni-v3-twap-manipulation/blob/master/cost-of-attack.pdf) on the topic.
+Furthermore, while it's still possible to manipulate on-chain prices, the presence of arbitrageurs, MEV, and regular users make doing so incredibly costly. The further use of TWAPs (time-weighted average prices) increases the cost exponentially by allowing arbitrageurs time to move funds between exchanges and profit greatly from trading. Please read [this related paper](https://github.com/adrastia-oracle/uni-v3-twap-manipulation/blob/master/cost-of-attack.pdf) on the topic.
 
-Assuming the precense of arbitrageurs, MEV, on/off ramps and bridges, and someone (anyone) to call Adrastia's simple update functions, Adrastia therefore delivers the highest level of secure, accurate, and reliable price feeds.
+Assuming the presence of arbitrageurs, MEV, on/off ramps and bridges, and someone (anyone) to call Adrastia's simple update functions, Adrastia, therefore, delivers the highest level of secure, accurate, and reliable price feeds.
 
 ## Install
 
@@ -140,7 +140,7 @@ contract PriceConsumer {
 
 ### Consuming oracle data
 
-To consume data from deployed oracles, import the one of the interfaces that the oracle contract implements, then call one of the consult functions.
+To consume data from deployed oracles, import one of the interfaces that the oracle contract implements, then call one of the consult functions.
 
 ### Maintaining an oracle
 
@@ -152,8 +152,8 @@ If any security vulnerabilities are found, please contact us via Discord (TylerE
 
 ## Overview
 
-### High level flow chart
-![High level flow chart](/assets/images/high-level-flow-chart.png)
+### High-level flow chart
+![High-level flow chart](/assets/images/high-level-flow-chart.png)
 
 ### Accumulators
 
@@ -161,7 +161,7 @@ Accumulators (`contracts/accumulators/`) are designed to track changing values s
 
 ### Oracles
 
-Oracles (`contracts/oracles/`) are designed to record observations to later provide consulations against these observations with a focus on gas efficiency when consulting. They typically update periodically and utilize time-weighted averages derived from accumulators to provide higher levels of manipulation resistance.
+Oracles (`contracts/oracles/`) are designed to record observations to later provide consultations against these observations with a focus on gas efficiency when consulting. They typically update periodically and utilize time-weighted averages derived from accumulators to provide higher levels of manipulation resistance.
 
 ## Limitations
 
@@ -169,24 +169,24 @@ Oracles (`contracts/oracles/`) are designed to record observations to later prov
 
 #### Cumulative value overflows and underflows
 
-While overflows and underflows in the math relating to cumulative values [usually] results in correct calculations, there's a scenario where it does not.
+While overflows and underflows in the math relating to cumulative values [usually] result in correct calculations, there's a scenario where it does not.
 
-Say the math is performed using 224 bit numbers. If the difference between two cumulative values is greater than or equal to 2^112, we run into a problem. Since we're using 112 bit numbers, the **difference** will overflow/underflow. It's okay for the cumulative values to overflow/underflow, but not the difference.
+Say the math is performed using 224-bit numbers. If the difference between two cumulative values is greater than or equal to 2^112, we run into a problem. Since we're using 112-bit numbers, the **difference** will overflow/underflow. It's okay for the cumulative values to overflow/underflow, but not the difference.
 
 Let's say we're using cumulative prices, and the first cumulative price is equal to 2^56. Then say the second cumulative value overflows, going back to zero, then eventually going to 2^56 again and this value is used in calculations. The difference between these two cumulative prices is 0, and the TWAP calculated will be equal to `0/deltaTime = 0`. This is incorrect, and the correct TWAP is actually `2^112/deltaTime`. Since the **difference** overflowed, the result is incorrect.
 
-When using accumulators, make sure to calculate the maximum period (deltaTime) that can be used with the maximum level of price/liquidity/value that can be reasonably expected. Also take note that the period (deltaTime) is optimistic and could become larger than expected if the accumulator is not being updated frequently enough.
+When using accumulators, make sure to calculate the maximum period (deltaTime) that can be used with the maximum level of price/liquidity/value that can be reasonably expected. Also, take note that the period (deltaTime) is optimistic and could become larger than expected if the accumulator is not updated frequently enough.
 
-Example using a liquidity accumulator for COMP with a fixed total supply of 10,000,000 and 18 decimal places. Let's say that the maximum amount of COMP we can reasonably expect in a DEX pool is 10% of the total supply. Then the maximum deltaTime before we run into problems is equal to `deltaTime = 2^112/(1,000,000*10^18) = 5192296858` seconds, or about 164 years.
+Here's an example using a liquidity accumulator for COMP with a fixed total supply of 10,000,000 and 18 decimal places. Let's say that the maximum amount of COMP we can reasonably expect in a DEX pool is 10% of the total supply. Then the maximum deltaTime before we run into problems is equal to `deltaTime = 2^112/(1,000,000*10^18) = 5192296858` seconds, or about 164 years.
 
 ## Assumptions
 
 - `liquidity <= 1,000,000,000*10^18` (w/ 18 decimal places)
-  - Liquidities can be stored in 112 bit numbers
+  - Liquidities can be stored in 112-bit numbers
 - `deltaTime < 5192296` (60 days)
   - Maximum time between two accumulations
 - `block.timestamp < 4294967296` (Feb 2106)
-  - Timestamps can be stored in 32 bit numbers
+  - Timestamps can be stored in 32-bit numbers
 
 ## Contributing
 

--- a/contracts/oracles/PeriodicAccumulationOracle.sol
+++ b/contracts/oracles/PeriodicAccumulationOracle.sol
@@ -78,7 +78,11 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
     ///   consider it to be out-of-date.
     /// @return The grace period in seconds.
     function accumulatorUpdateDelayTolerance() public view virtual returns (uint256) {
-        return 1800; // 30 minutes
+        // We trade some freshness for greater reliability. Using too low of a tolerance reduces the cost of DoS.
+        // Furthermore, large price fluctuations can require tokens to be bridged by arbitrageurs to fix DEX prices,
+        // and this can take time. Price accumulators may not get updated during this time as we may require on-chain
+        // prices to closely match off-chain prices.
+        return 1 hours;
     }
 
     /// @notice The grace period that we allow for the oracle to be in need of an update before we discard the last

--- a/contracts/test/oracles/PeriodicAccumulationOracleStub.sol
+++ b/contracts/test/oracles/PeriodicAccumulationOracleStub.sol
@@ -51,6 +51,26 @@ contract PeriodicAccumulationOracleStub is PeriodicAccumulationOracle {
         liquidityAccumulation.timestamp = timestamp;
     }
 
+    function stubSetPriceAccumulation(address token, uint112 cumulativePrice, uint32 timestamp) public {
+        AccumulationLibrary.PriceAccumulator storage priceAccumulation = priceAccumulations[token];
+
+        priceAccumulation.cumulativePrice = cumulativePrice;
+        priceAccumulation.timestamp = timestamp;
+    }
+
+    function stubSetLiquidityAccumulation(
+        address token,
+        uint112 cumulativeTokenLiquidity,
+        uint112 cumulativeQuoteTokenLiquidity,
+        uint32 timestamp
+    ) public {
+        AccumulationLibrary.LiquidityAccumulator storage liquidityAccumulation = liquidityAccumulations[token];
+
+        liquidityAccumulation.cumulativeTokenLiquidity = cumulativeTokenLiquidity;
+        liquidityAccumulation.cumulativeQuoteTokenLiquidity = cumulativeQuoteTokenLiquidity;
+        liquidityAccumulation.timestamp = timestamp;
+    }
+
     function overrideNeedsUpdate(bool overridden, bool needsUpdate_) public {
         config.needsUpdateOverridden = overridden;
         config.needsUpdate = needsUpdate_;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrastia-oracle/adrastia-core",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0",
   "main": "index.js",
   "author": "TRILEZ SOFTWARE INC.",
   "license": "MIT",


### PR DESCRIPTION
### Oracles
- Change PeriodicAccumulationOracle freshness metric to use accumulator heartbeats
- Add IOracle#liquidityDecimals
- Make AggregatedOracle's minimum liquidity values operate with respect to its liquidity decimals
- Bug fix: Make PeriodicAccumulationOracle discard old accumulations when updating to prevent older than desired time-weighted averages from being stored in oracle observations

### Accumulators
- Promote cumulative prices to uint224 from uint112
- Parameterize and standardize liquidity decimals
  - Rather than liquidity using the same number of decimals as the respective token, liquidity now uses the number of decimals specified in the constructor. Both the queried token and the quote token now always use the same number of decimal places.
- Introduce geometric and harmonic time-weighted averages
- Bug fix: time-weighted values are now calculated outside of unchecked blocks as overflow is not desired
- Add IAccumulator#heartbeat