### PR TITLE
Release/v3.0.0 beta.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Adrastia Core
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-![2904 out of 2904 tests passing](https://img.shields.io/badge/tests-2904/2904%20passing-brightgreen.svg?style=flat-square)
+![3060 out of 3060 tests passing](https://img.shields.io/badge/tests-3060/3060%20passing-brightgreen.svg?style=flat-square)
 ![test-coverage 100%](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg?style=flat-square)
 
 Adrastia Core is a set of Solidity smart contracts for building EVM oracle solutions.

--- a/contracts/interfaces/IHistoricalLiquidityAccumulationOracle.sol
+++ b/contracts/interfaces/IHistoricalLiquidityAccumulationOracle.sol
@@ -1,0 +1,57 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0 <0.9.0;
+
+import "../libraries/AccumulationLibrary.sol";
+
+/**
+ * @title IHistoricalLiquidityAccumulationOracle
+ * @notice An interface that defines an oracle contract that stores historical liquidity accumulations.
+ */
+interface IHistoricalLiquidityAccumulationOracle {
+    /// @notice Gets a liquidity accumulation for a token at a specific index.
+    /// @param token The address of the token to get the accumulation for.
+    /// @param index The index of the accumulation to get, where index 0 contains the latest accumulation, and the last
+    ///   index contains the oldest accumulation (uses reverse chronological ordering).
+    /// @return The accumulation for the token at the specified index.
+    function getLiquidityAccumulationAt(
+        address token,
+        uint256 index
+    ) external view returns (AccumulationLibrary.LiquidityAccumulator memory);
+
+    /// @notice Gets the latest liquidity accumulations for a token.
+    /// @param token The address of the token to get the accumulations for.
+    /// @param amount The number of accumulations to get.
+    /// @return The latest accumulations for the token, in reverse chronological order, from newest to oldest.
+    function getLiquidityAccumulations(
+        address token,
+        uint256 amount
+    ) external view returns (AccumulationLibrary.LiquidityAccumulator[] memory);
+
+    /// @notice Gets the latest liquidity accumulations for a token.
+    /// @param token The address of the token to get the accumulations for.
+    /// @param amount The number of accumulations to get.
+    /// @param offset The index of the first accumulations to get (default: 0).
+    /// @param increment The increment between accumulations to get (default: 1).
+    /// @return The latest accumulations for the token, in reverse chronological order, from newest to oldest.
+    function getLiquidityAccumulations(
+        address token,
+        uint256 amount,
+        uint256 offset,
+        uint256 increment
+    ) external view returns (AccumulationLibrary.LiquidityAccumulator[] memory);
+
+    /// @notice Gets the number of liquidity accumulations for a token.
+    /// @param token The address of the token to get the number of accumulations for.
+    /// @return count The number of accumulations for the token.
+    function getLiquidityAccumulationsCount(address token) external view returns (uint256);
+
+    /// @notice Gets the capacity of liquidity accumulations for a token.
+    /// @param token The address of the token to get the capacity of accumulations for.
+    /// @return capacity The capacity of accumulations for the token.
+    function getLiquidityAccumulationsCapacity(address token) external view returns (uint256);
+
+    /// @notice Sets the capacity of liquidity accumulations for a token.
+    /// @param token The address of the token to set the capacity of accumulations for.
+    /// @param amount The new capacity of accumulations for the token.
+    function setLiquidityAccumulationsCapacity(address token, uint256 amount) external;
+}

--- a/contracts/interfaces/IHistoricalOracle.sol
+++ b/contracts/interfaces/IHistoricalOracle.sol
@@ -1,0 +1,44 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0 <0.9.0;
+
+import "../libraries/ObservationLibrary.sol";
+
+/**
+ * @title IHistoricalOracle
+ * @notice An interface that defines an oracle contract that stores historical observations.
+ */
+interface IHistoricalOracle {
+    /// @notice Gets an observation for a token at a specific index.
+    /// @param token The address of the token to get the observation for.
+    /// @param index The index of the observation to get, where index 0 contains the latest observation, and the last
+    ///   index contains the oldest observation (uses reverse chronological ordering).
+    /// @return observation The observation for the token at the specified index.
+    function getObservationAt(
+        address token,
+        uint256 index
+    ) external view returns (ObservationLibrary.Observation memory);
+
+    /// @notice Gets the latest observations for a token.
+    /// @param token The address of the token to get the observations for.
+    /// @param amount The number of observations to get.
+    /// @return observations The latest observations for the token, in reverse chronological order, from newest to oldest.
+    function getObservations(
+        address token,
+        uint256 amount
+    ) external view returns (ObservationLibrary.Observation[] memory);
+
+    /// @notice Gets the number of observations for a token.
+    /// @param token The address of the token to get the number of observations for.
+    /// @return count The number of observations for the token.
+    function getObservationsCount(address token) external view returns (uint256);
+
+    /// @notice Gets the capacity of observations for a token.
+    /// @param token The address of the token to get the capacity of observations for.
+    /// @return capacity The capacity of observations for the token.
+    function getObservationsCapacity(address token) external view returns (uint256);
+
+    /// @notice Sets the capacity of observations for a token.
+    /// @param token The address of the token to set the capacity of observations for.
+    /// @param amount The new capacity of observations for the token.
+    function setObservationsCapacity(address token, uint256 amount) external;
+}

--- a/contracts/interfaces/IHistoricalOracle.sol
+++ b/contracts/interfaces/IHistoricalOracle.sol
@@ -27,6 +27,19 @@ interface IHistoricalOracle {
         uint256 amount
     ) external view returns (ObservationLibrary.Observation[] memory);
 
+    /// @notice Gets the latest observations for a token.
+    /// @param token The address of the token to get the observations for.
+    /// @param amount The number of observations to get.
+    /// @param offset The index of the first observation to get (default: 0).
+    /// @param increment The increment between observations to get (default: 1).
+    /// @return observations The latest observations for the token, in reverse chronological order, from newest to oldest.
+    function getObservations(
+        address token,
+        uint256 amount,
+        uint256 offset,
+        uint256 increment
+    ) external view returns (ObservationLibrary.Observation[] memory);
+
     /// @notice Gets the number of observations for a token.
     /// @param token The address of the token to get the number of observations for.
     /// @return count The number of observations for the token.

--- a/contracts/interfaces/IHistoricalPriceAccumulationOracle.sol
+++ b/contracts/interfaces/IHistoricalPriceAccumulationOracle.sol
@@ -1,0 +1,57 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0 <0.9.0;
+
+import "../libraries/AccumulationLibrary.sol";
+
+/**
+ * @title IHistoricalPriceAccumulationOracle
+ * @notice An interface that defines an oracle contract that stores historical price accumulations.
+ */
+interface IHistoricalPriceAccumulationOracle {
+    /// @notice Gets a price accumulation for a token at a specific index.
+    /// @param token The address of the token to get the accumulation for.
+    /// @param index The index of the accumulation to get, where index 0 contains the latest accumulation, and the last
+    ///   index contains the oldest accumulation (uses reverse chronological ordering).
+    /// @return The accumulation for the token at the specified index.
+    function getPriceAccumulationAt(
+        address token,
+        uint256 index
+    ) external view returns (AccumulationLibrary.PriceAccumulator memory);
+
+    /// @notice Gets the latest price accumulations for a token.
+    /// @param token The address of the token to get the accumulations for.
+    /// @param amount The number of accumulations to get.
+    /// @return The latest accumulations for the token, in reverse chronological order, from newest to oldest.
+    function getPriceAccumulations(
+        address token,
+        uint256 amount
+    ) external view returns (AccumulationLibrary.PriceAccumulator[] memory);
+
+    /// @notice Gets the latest price accumulations for a token.
+    /// @param token The address of the token to get the accumulations for.
+    /// @param amount The number of accumulations to get.
+    /// @param offset The index of the first accumulations to get (default: 0).
+    /// @param increment The increment between accumulations to get (default: 1).
+    /// @return The latest accumulations for the token, in reverse chronological order, from newest to oldest.
+    function getPriceAccumulations(
+        address token,
+        uint256 amount,
+        uint256 offset,
+        uint256 increment
+    ) external view returns (AccumulationLibrary.PriceAccumulator[] memory);
+
+    /// @notice Gets the number of price accumulations for a token.
+    /// @param token The address of the token to get the number of accumulations for.
+    /// @return count The number of accumulations for the token.
+    function getPriceAccumulationsCount(address token) external view returns (uint256);
+
+    /// @notice Gets the capacity of price accumulations for a token.
+    /// @param token The address of the token to get the capacity of accumulations for.
+    /// @return capacity The capacity of accumulations for the token.
+    function getPriceAccumulationsCapacity(address token) external view returns (uint256);
+
+    /// @notice Sets the capacity of price accumulations for a token.
+    /// @param token The address of the token to set the capacity of accumulations for.
+    /// @param amount The new capacity of accumulations for the token.
+    function setPriceAccumulationsCapacity(address token, uint256 amount) external;
+}

--- a/contracts/interfaces/IPeriodic.sol
+++ b/contracts/interfaces/IPeriodic.sol
@@ -10,4 +10,8 @@ interface IPeriodic {
     /// @notice Gets the period, in seconds.
     /// @return periodSeconds The period, in seconds.
     function period() external view returns (uint256 periodSeconds);
+
+    // @notice Gets the number of observations made every period.
+    // @return granularity The number of observations made every period.
+    function granularity() external view returns (uint256 granularity);
 }

--- a/contracts/oracles/AbstractOracle.sol
+++ b/contracts/oracles/AbstractOracle.sol
@@ -25,12 +25,18 @@ abstract contract AbstractOracle is IERC165, IOracle, SimpleQuotationMetadata {
     /// @inheritdoc IUpdateable
     function canUpdate(bytes memory data) public view virtual override returns (bool);
 
+    function getLatestObservation(
+        address token
+    ) public view virtual returns (ObservationLibrary.Observation memory observation) {
+        return observations[token];
+    }
+
     /// @param data The encoded address of the token for which the update relates to.
     /// @inheritdoc IUpdateable
     function lastUpdateTime(bytes memory data) public view virtual override returns (uint256) {
         address token = abi.decode(data, (address));
 
-        return observations[token].timestamp;
+        return getLatestObservation(token).timestamp;
     }
 
     /// @param data The encoded address of the token for which the update relates to.
@@ -42,7 +48,7 @@ abstract contract AbstractOracle is IERC165, IOracle, SimpleQuotationMetadata {
     function consultPrice(address token) public view virtual override returns (uint112 price) {
         if (token == quoteTokenAddress()) return uint112(10 ** quoteTokenDecimals());
 
-        ObservationLibrary.Observation storage observation = observations[token];
+        ObservationLibrary.Observation memory observation = getLatestObservation(token);
 
         require(observation.timestamp != 0, "AbstractOracle: MISSING_OBSERVATION");
 
@@ -59,7 +65,7 @@ abstract contract AbstractOracle is IERC165, IOracle, SimpleQuotationMetadata {
             return price;
         }
 
-        ObservationLibrary.Observation storage observation = observations[token];
+        ObservationLibrary.Observation memory observation = getLatestObservation(token);
 
         require(observation.timestamp != 0, "AbstractOracle: MISSING_OBSERVATION");
         require(block.timestamp <= observation.timestamp + maxAge, "AbstractOracle: RATE_TOO_OLD");
@@ -73,7 +79,7 @@ abstract contract AbstractOracle is IERC165, IOracle, SimpleQuotationMetadata {
     ) public view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
         if (token == quoteTokenAddress()) return (0, 0);
 
-        ObservationLibrary.Observation storage observation = observations[token];
+        ObservationLibrary.Observation memory observation = getLatestObservation(token);
 
         require(observation.timestamp != 0, "AbstractOracle: MISSING_OBSERVATION");
 
@@ -94,7 +100,7 @@ abstract contract AbstractOracle is IERC165, IOracle, SimpleQuotationMetadata {
             return (tokenLiquidity, quoteTokenLiquidity);
         }
 
-        ObservationLibrary.Observation storage observation = observations[token];
+        ObservationLibrary.Observation memory observation = getLatestObservation(token);
 
         require(observation.timestamp != 0, "AbstractOracle: MISSING_OBSERVATION");
         require(block.timestamp <= observation.timestamp + maxAge, "AbstractOracle: RATE_TOO_OLD");
@@ -109,7 +115,7 @@ abstract contract AbstractOracle is IERC165, IOracle, SimpleQuotationMetadata {
     ) public view virtual override returns (uint112 price, uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
         if (token == quoteTokenAddress()) return (uint112(10 ** quoteTokenDecimals()), 0, 0);
 
-        ObservationLibrary.Observation storage observation = observations[token];
+        ObservationLibrary.Observation memory observation = getLatestObservation(token);
 
         require(observation.timestamp != 0, "AbstractOracle: MISSING_OBSERVATION");
 
@@ -127,7 +133,7 @@ abstract contract AbstractOracle is IERC165, IOracle, SimpleQuotationMetadata {
 
         if (maxAge == 0) return instantFetch(token);
 
-        ObservationLibrary.Observation storage observation = observations[token];
+        ObservationLibrary.Observation memory observation = getLatestObservation(token);
 
         require(observation.timestamp != 0, "AbstractOracle: MISSING_OBSERVATION");
         require(block.timestamp <= observation.timestamp + maxAge, "AbstractOracle: RATE_TOO_OLD");

--- a/contracts/oracles/AbstractOracle.sol
+++ b/contracts/oracles/AbstractOracle.sol
@@ -9,8 +9,6 @@ import "../libraries/ObservationLibrary.sol";
 import "../utils/SimpleQuotationMetadata.sol";
 
 abstract contract AbstractOracle is IERC165, IOracle, SimpleQuotationMetadata {
-    mapping(address => ObservationLibrary.Observation) public observations;
-
     constructor(address quoteToken_) SimpleQuotationMetadata(quoteToken_) {}
 
     /// @param data The encoded address of the token for which to perform the update.
@@ -27,9 +25,7 @@ abstract contract AbstractOracle is IERC165, IOracle, SimpleQuotationMetadata {
 
     function getLatestObservation(
         address token
-    ) public view virtual returns (ObservationLibrary.Observation memory observation) {
-        return observations[token];
-    }
+    ) public view virtual returns (ObservationLibrary.Observation memory observation);
 
     /// @param data The encoded address of the token for which the update relates to.
     /// @inheritdoc IUpdateable

--- a/contracts/oracles/AggregatedOracle.sol
+++ b/contracts/oracles/AggregatedOracle.sol
@@ -185,7 +185,7 @@ contract AggregatedOracle is IAggregatedOracle, IHistoricalOracle, PeriodicOracl
 
         require(index < meta.size, "AggregatedOracle: INVALID_INDEX");
 
-        uint256 bufferIndex = uint256((int256(uint256(meta.end)) - int256(index)) % int256(uint256(meta.size)));
+        uint256 bufferIndex = meta.end < index ? meta.end + meta.size - index : meta.end - index;
 
         return observationBuffers[token][bufferIndex];
     }

--- a/contracts/oracles/AggregatedOracle.sol
+++ b/contracts/oracles/AggregatedOracle.sol
@@ -78,6 +78,11 @@ contract AggregatedOracle is IAggregatedOracle, IHistoricalOracle, PeriodicOracl
     /// @param newCapacity The new capacity of the observation buffer.
     event ObservationCapacityIncreased(address indexed token, uint256 oldCapacity, uint256 newCapacity);
 
+    /// @notice Event emitted when an observation buffer's capacity is initialized.
+    /// @param token The token for which the observation buffer's capacity was initialized.
+    /// @param capacity The capacity of the observation buffer.
+    event ObservationCapacityInitialized(address indexed token, uint256 capacity);
+
     /*
      * Constructors
      */
@@ -408,6 +413,8 @@ contract AggregatedOracle is IAggregatedOracle, IHistoricalOracle, PeriodicOracl
         meta.end = 0;
         meta.size = 0;
         meta.maxSize = _initialCardinality;
+
+        emit ObservationCapacityInitialized(token, meta.maxSize);
     }
 
     function push(address token, ObservationLibrary.Observation memory observation) internal virtual {

--- a/contracts/oracles/AggregatedOracle.sol
+++ b/contracts/oracles/AggregatedOracle.sol
@@ -307,6 +307,7 @@ contract AggregatedOracle is IAggregatedOracle, IHistoricalOracle, PeriodicOracl
     ) public view virtual override(PeriodicOracle, ExplicitQuotationMetadata) returns (bool) {
         return
             interfaceId == type(IAggregatedOracle).interfaceId ||
+            interfaceId == type(IHistoricalOracle).interfaceId ||
             ExplicitQuotationMetadata.supportsInterface(interfaceId) ||
             PeriodicOracle.supportsInterface(interfaceId);
     }

--- a/contracts/oracles/AggregatedOracle.sol
+++ b/contracts/oracles/AggregatedOracle.sol
@@ -38,9 +38,9 @@ contract AggregatedOracle is IAggregatedOracle, IHistoricalOracle, PeriodicOracl
         uint16 maxSize;
     }
 
-    mapping(address => BufferMetadata) public observationBufferMetadata;
+    mapping(address => BufferMetadata) internal observationBufferMetadata;
 
-    mapping(address => ObservationLibrary.Observation[]) public observationBuffers;
+    mapping(address => ObservationLibrary.Observation[]) internal observationBuffers;
 
     /// @notice The minimum quote token denominated value of the token liquidity, scaled by this oracle's liquidity
     /// decimals, required for all underlying oracles to be considered valid and thus included in the aggregation.

--- a/contracts/oracles/AggregatedOracle.sol
+++ b/contracts/oracles/AggregatedOracle.sol
@@ -32,10 +32,10 @@ contract AggregatedOracle is IAggregatedOracle, IHistoricalOracle, PeriodicOracl
     }
 
     struct BufferMetadata {
-        uint8 start;
-        uint8 end;
-        uint8 size;
-        uint8 maxSize;
+        uint16 start;
+        uint16 end;
+        uint16 size;
+        uint16 maxSize;
     }
 
     mapping(address => BufferMetadata) public observationBufferMetadata;
@@ -55,7 +55,7 @@ contract AggregatedOracle is IAggregatedOracle, IHistoricalOracle, PeriodicOracl
 
     uint8 internal immutable _liquidityDecimals;
 
-    uint8 internal immutable _initialCardinality;
+    uint16 internal immutable _initialCardinality;
 
     /*
      * Internal variables
@@ -223,7 +223,7 @@ contract AggregatedOracle is IAggregatedOracle, IHistoricalOracle, PeriodicOracl
 
     /// @inheritdoc IHistoricalOracle
     /// @param amount The new capacity of observations for the token. Must be greater than the current capacity, but
-    ///   less than 256.
+    ///   less than 65536.
     function setObservationsCapacity(address token, uint256 amount) external virtual override {
         BufferMetadata storage meta = observationBufferMetadata[token];
         if (meta.maxSize == 0) {
@@ -232,7 +232,7 @@ contract AggregatedOracle is IAggregatedOracle, IHistoricalOracle, PeriodicOracl
         }
 
         require(amount >= meta.maxSize, "AggregatedOracle: CAPACITY_CANNOT_BE_DECREASED");
-        require(amount <= type(uint8).max, "AggregatedOracle: CAPACITY_TOO_LARGE");
+        require(amount <= type(uint16).max, "AggregatedOracle: CAPACITY_TOO_LARGE");
 
         ObservationLibrary.Observation[] storage observationBuffer = observationBuffers[token];
 
@@ -249,7 +249,7 @@ contract AggregatedOracle is IAggregatedOracle, IHistoricalOracle, PeriodicOracl
             emit ObservationCapacityIncreased(token, meta.maxSize, amount);
 
             // Update the metadata
-            meta.maxSize = uint8(amount);
+            meta.maxSize = uint16(amount);
         }
     }
 

--- a/contracts/oracles/AggregatedOracle.sol
+++ b/contracts/oracles/AggregatedOracle.sol
@@ -72,10 +72,11 @@ contract AggregatedOracle is IAggregatedOracle, PeriodicOracle, ExplicitQuotatio
         address[] memory oracles_,
         TokenSpecificOracle[] memory tokenSpecificOracles_,
         uint256 period_,
+        uint256 granularity_,
         uint256 minimumTokenLiquidityValue_,
         uint256 minimumQuoteTokenLiquidity_
     )
-        PeriodicOracle(quoteTokenAddress_, period_)
+        PeriodicOracle(quoteTokenAddress_, period_, granularity_)
         ExplicitQuotationMetadata(quoteTokenName_, quoteTokenAddress_, quoteTokenSymbol_, quoteTokenDecimals_)
     {
         require(oracles_.length > 0 || tokenSpecificOracles_.length > 0, "AggregatedOracle: MISSING_ORACLES");

--- a/contracts/oracles/PeriodicAccumulationOracle.sol
+++ b/contracts/oracles/PeriodicAccumulationOracle.sol
@@ -108,8 +108,9 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
         return 1 hours;
     }
 
-    /// @notice The grace period that we allow for the oracle to be in need of an update before we discard the last
-    ///   accumulation. If this grace period is exceeded, it will take two updates to get a new observation.
+    /// @notice The grace period that we allow for the oracle to be in need of an update (as the sum of all update
+    ///   delays in a period) before we discard the last accumulation. If this grace period is exceeded, it will take
+    ///   more updates to get a new observation.
     /// @dev This is to prevent longer time-weighted averages than we desire. The maximum period is then the period of
     ///   this oracle plus this grace period.
     /// @return The grace period in seconds.
@@ -117,7 +118,7 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
         // We tolerate two missed periods plus 5 minutes (to allow for some time to update the oracles).
         // We trade off some freshness for greater reliability. Using too low of a tolerance reduces the cost of DoS
         // attacks.
-        return (_updateEvery * 2) + 5 minutes;
+        return (period * 2) + 5 minutes;
     }
 
     function initializeBuffers(address token) internal virtual {

--- a/contracts/oracles/PeriodicAccumulationOracle.sol
+++ b/contracts/oracles/PeriodicAccumulationOracle.sol
@@ -53,6 +53,22 @@ contract PeriodicAccumulationOracle is
     /// @param capacity The capacity of the accumulation buffer.
     event AccumulationCapacityInitialized(address indexed token, uint256 capacity);
 
+    /// @notice Event emitted when an accumulation is pushed to the buffer.
+    /// @param token The token for which the accumulation was pushed.
+    /// @param priceCumulative The cumulative price of the token.
+    /// @param priceTimestamp The timestamp of the cumulative price.
+    /// @param tokenLiquidityCumulative The cumulative token liquidity of the token.
+    /// @param quoteTokenLiquidityCumulative The cumulative quote token liquidity of the token.
+    /// @param liquidityTimestamp The timestamp of the cumulative liquidity.
+    event AccumulationPushed(
+        address indexed token,
+        uint256 priceCumulative,
+        uint256 priceTimestamp,
+        uint256 tokenLiquidityCumulative,
+        uint256 quoteTokenLiquidityCumulative,
+        uint256 liquidityTimestamp
+    );
+
     constructor(
         address liquidityAccumulator_,
         address priceAccumulator_,
@@ -446,6 +462,15 @@ contract PeriodicAccumulationOracle is
 
         priceAccumulationBuffers[token][meta.end] = priceAccumulation;
         liquidityAccumulationBuffers[token][meta.end] = liquidityAccumulation;
+
+        emit AccumulationPushed(
+            token,
+            priceAccumulation.cumulativePrice,
+            priceAccumulation.timestamp,
+            liquidityAccumulation.cumulativeTokenLiquidity,
+            liquidityAccumulation.cumulativeQuoteTokenLiquidity,
+            liquidityAccumulation.timestamp
+        );
 
         if (meta.size < meta.maxSize && meta.end == meta.size) {
             // We are at the end of the array and we have not yet filled it

--- a/contracts/oracles/PeriodicAccumulationOracle.sol
+++ b/contracts/oracles/PeriodicAccumulationOracle.sol
@@ -34,19 +34,24 @@ contract PeriodicAccumulationOracle is
     address public immutable override liquidityAccumulator;
     address public immutable override priceAccumulator;
 
-    mapping(address => BufferMetadata) public accumulationBufferMetadata;
+    mapping(address => BufferMetadata) internal accumulationBufferMetadata;
 
-    mapping(address => AccumulationLibrary.PriceAccumulator[]) public priceAccumulationBuffers;
-    mapping(address => AccumulationLibrary.LiquidityAccumulator[]) public liquidityAccumulationBuffers;
+    mapping(address => AccumulationLibrary.PriceAccumulator[]) internal priceAccumulationBuffers;
+    mapping(address => AccumulationLibrary.LiquidityAccumulator[]) internal liquidityAccumulationBuffers;
 
     mapping(address => ObservationLibrary.Observation) internal observations;
 
     /// @notice Event emitted when an accumulation buffer's capacity is increased past the initial capacity.
     /// @dev Buffer initialization does not emit an event.
     /// @param token The token for which the accumulation buffer's capacity was increased.
-    /// @param oldCapacity The previous capacity of the observation buffer.
-    /// @param newCapacity The new capacity of the observation buffer.
+    /// @param oldCapacity The previous capacity of the accumulation buffer.
+    /// @param newCapacity The new capacity of the accumulation buffer.
     event AccumulationCapacityIncreased(address indexed token, uint256 oldCapacity, uint256 newCapacity);
+
+    /// @notice Event emitted when an accumulation buffer's capacity is initialized.
+    /// @param token The token for which the accumulation buffer's capacity was initialized.
+    /// @param capacity The capacity of the accumulation buffer.
+    event AccumulationCapacityInitialized(address indexed token, uint256 capacity);
 
     constructor(
         address liquidityAccumulator_,
@@ -358,6 +363,8 @@ contract PeriodicAccumulationOracle is
         meta.end = 0;
         meta.size = 0;
         meta.maxSize = uint16(granularity);
+
+        emit AccumulationCapacityInitialized(token, meta.maxSize);
     }
 
     function push(

--- a/contracts/oracles/PeriodicAccumulationOracle.sol
+++ b/contracts/oracles/PeriodicAccumulationOracle.sol
@@ -30,6 +30,8 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
     mapping(address => AccumulationLibrary.PriceAccumulator[]) public priceAccumulationBuffers;
     mapping(address => AccumulationLibrary.LiquidityAccumulator[]) public liquidityAccumulationBuffers;
 
+    mapping(address => ObservationLibrary.Observation) internal observations;
+
     constructor(
         address liquidityAccumulator_,
         address priceAccumulator_,
@@ -39,6 +41,12 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
     ) PeriodicOracle(quoteToken_, period_, granularity_) {
         liquidityAccumulator = liquidityAccumulator_;
         priceAccumulator = priceAccumulator_;
+    }
+
+    function getLatestObservation(
+        address token
+    ) public view virtual override returns (ObservationLibrary.Observation memory observation) {
+        return observations[token];
     }
 
     /// @inheritdoc PeriodicOracle

--- a/contracts/oracles/PeriodicAccumulationOracle.sol
+++ b/contracts/oracles/PeriodicAccumulationOracle.sol
@@ -389,6 +389,8 @@ contract PeriodicAccumulationOracle is
                 }
             }
 
+            meta.end = (meta.end + 1) % meta.maxSize;
+
             // Check if we have enough accumulations for a new observation
             if (meta.size >= granularity) {
                 uint256 startIndex = meta.end < granularity
@@ -433,8 +435,6 @@ contract PeriodicAccumulationOracle is
                     );
                 }
             }
-
-            meta.end = (meta.end + 1) % meta.maxSize;
         }
 
         priceAccumulationBuffers[token][meta.end] = priceAccumulation;

--- a/contracts/oracles/PeriodicAccumulationOracle.sol
+++ b/contracts/oracles/PeriodicAccumulationOracle.sol
@@ -108,7 +108,7 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
         // We tolerate two missed periods plus 5 minutes (to allow for some time to update the oracles).
         // We trade off some freshness for greater reliability. Using too low of a tolerance reduces the cost of DoS
         // attacks.
-        return (period * 2) + 5 minutes;
+        return (_updateEvery * 2) + 5 minutes;
     }
 
     function initializeBuffers(address token) internal virtual {

--- a/contracts/oracles/PeriodicAccumulationOracle.sol
+++ b/contracts/oracles/PeriodicAccumulationOracle.sol
@@ -17,9 +17,9 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
     using SafeCast for uint256;
 
     struct BufferMetadata {
-        uint8 start;
-        uint8 end;
-        uint8 size;
+        uint16 start;
+        uint16 end;
+        uint16 size;
     }
 
     address public immutable override liquidityAccumulator;
@@ -195,7 +195,7 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
                 return false;
             }
 
-            meta.end = (meta.end + 1) % uint8(granularity);
+            meta.end = (meta.end + 1) % uint16(granularity);
         }
 
         priceAccumulationBuffers[token][meta.end] = priceAccumulation;
@@ -205,7 +205,7 @@ contract PeriodicAccumulationOracle is PeriodicOracle, IHasLiquidityAccumulator,
             meta.size++;
         } else {
             // start was just overwritten
-            meta.start = (meta.start + 1) % uint8(granularity);
+            meta.start = (meta.start + 1) % uint16(granularity);
         }
 
         return true;

--- a/contracts/oracles/PeriodicOracle.sol
+++ b/contracts/oracles/PeriodicOracle.sol
@@ -7,11 +7,19 @@ import "./AbstractOracle.sol";
 
 abstract contract PeriodicOracle is IPeriodic, AbstractOracle {
     uint256 public immutable override period;
+    uint256 public immutable override granularity;
 
-    constructor(address quoteToken_, uint256 period_) AbstractOracle(quoteToken_) {
+    uint internal immutable _updateEvery;
+
+    constructor(address quoteToken_, uint256 period_, uint256 granularity_) AbstractOracle(quoteToken_) {
         require(period_ > 0, "PeriodicOracle: INVALID_PERIOD");
+        require(granularity_ > 0, "PeriodicOracle: INVALID_GRANULARITY");
+        require(period_ % granularity_ == 0, "PeriodicOracle: INVALID_PERIOD_GRANULARITY");
 
         period = period_;
+        granularity = granularity_;
+
+        _updateEvery = period_ / granularity_;
     }
 
     /// @inheritdoc AbstractOracle
@@ -23,7 +31,7 @@ abstract contract PeriodicOracle is IPeriodic, AbstractOracle {
 
     /// @inheritdoc AbstractOracle
     function needsUpdate(bytes memory data) public view virtual override returns (bool) {
-        return timeSinceLastUpdate(data) >= period;
+        return timeSinceLastUpdate(data) >= _updateEvery;
     }
 
     /// @inheritdoc AbstractOracle

--- a/contracts/test/InterfaceIds.sol
+++ b/contracts/test/InterfaceIds.sol
@@ -13,6 +13,7 @@ import "../interfaces/IPriceOracle.sol";
 import "../interfaces/IQuoteToken.sol";
 import "../interfaces/IUpdateable.sol";
 import "../interfaces/IAccumulator.sol";
+import "../interfaces/IHistoricalOracle.sol";
 
 contract InterfaceIds {
     function iAggregatedOracle() external pure returns (bytes4) {
@@ -61,5 +62,9 @@ contract InterfaceIds {
 
     function iAccumulator() external pure returns (bytes4) {
         return type(IAccumulator).interfaceId;
+    }
+
+    function iHistoricalOracle() external pure returns (bytes4) {
+        return type(IHistoricalOracle).interfaceId;
     }
 }

--- a/contracts/test/InterfaceIds.sol
+++ b/contracts/test/InterfaceIds.sol
@@ -14,6 +14,8 @@ import "../interfaces/IQuoteToken.sol";
 import "../interfaces/IUpdateable.sol";
 import "../interfaces/IAccumulator.sol";
 import "../interfaces/IHistoricalOracle.sol";
+import "../interfaces/IHistoricalPriceAccumulationOracle.sol";
+import "../interfaces/IHistoricalLiquidityAccumulationOracle.sol";
 
 contract InterfaceIds {
     function iAggregatedOracle() external pure returns (bytes4) {
@@ -66,5 +68,13 @@ contract InterfaceIds {
 
     function iHistoricalOracle() external pure returns (bytes4) {
         return type(IHistoricalOracle).interfaceId;
+    }
+
+    function iHistoricalPriceAccumulationOracle() external pure returns (bytes4) {
+        return type(IHistoricalPriceAccumulationOracle).interfaceId;
+    }
+
+    function iHistoricalLiquidityAccumulationOracle() external pure returns (bytes4) {
+        return type(IHistoricalLiquidityAccumulationOracle).interfaceId;
     }
 }

--- a/contracts/test/oracles/AggregatedOracleStub.sol
+++ b/contracts/test/oracles/AggregatedOracleStub.sol
@@ -32,6 +32,7 @@ contract AggregatedOracleStub is AggregatedOracle {
         address[] memory oracles_,
         AggregatedOracle.TokenSpecificOracle[] memory _tokenSpecificOracles,
         uint256 period_,
+        uint256 granularity_,
         uint256 minimumTokenLiquidityValue_,
         uint256 minimumQuoteTokenLiquidity_
     )
@@ -44,6 +45,7 @@ contract AggregatedOracleStub is AggregatedOracle {
             oracles_,
             _tokenSpecificOracles,
             period_,
+            granularity_,
             minimumTokenLiquidityValue_,
             minimumQuoteTokenLiquidity_
         )

--- a/contracts/test/oracles/AggregatedOracleStub.sol
+++ b/contracts/test/oracles/AggregatedOracleStub.sol
@@ -70,12 +70,14 @@ contract AggregatedOracleStub is AggregatedOracle {
         uint112 quoteTokenLiquidity,
         uint32 timestamp
     ) public {
-        ObservationLibrary.Observation storage observation = observations[token];
+        ObservationLibrary.Observation memory observation;
 
         observation.price = price;
         observation.tokenLiquidity = tokenLiquidity;
         observation.quoteTokenLiquidity = quoteTokenLiquidity;
         observation.timestamp = timestamp;
+
+        push(token, observation);
     }
 
     function overrideNeedsUpdate(bool overridden, bool needsUpdate_) public {

--- a/contracts/test/oracles/AggregatedOracleStub.sol
+++ b/contracts/test/oracles/AggregatedOracleStub.sol
@@ -53,6 +53,31 @@ contract AggregatedOracleStub is AggregatedOracle {
         overrideValidateUnderlyingConsultation(true, true); // Skip validation by default
     }
 
+    function stubPush(
+        address token,
+        uint112 price,
+        uint112 tokenLiquidity,
+        uint112 quoteTokenLiquidity,
+        uint32 timestamp
+    ) public {
+        ObservationLibrary.Observation memory observation;
+
+        observation.price = price;
+        observation.tokenLiquidity = tokenLiquidity;
+        observation.quoteTokenLiquidity = quoteTokenLiquidity;
+        observation.timestamp = timestamp;
+
+        push(token, observation);
+    }
+
+    function stubInitializeBuffers(address token) public {
+        initializeBuffers(token);
+    }
+
+    function stubInitialCardinality() public view returns (uint256) {
+        return _initialCardinality;
+    }
+
     function stubSetLiquidityDecimals(uint8 decimals) public {
         config.liquidityDecimalsOverridden = true;
         config.liquidityDecimals = decimals;

--- a/contracts/test/oracles/MockOracle.sol
+++ b/contracts/test/oracles/MockOracle.sol
@@ -15,10 +15,18 @@ contract MockOracle is AbstractOracle {
 
     uint8 _liquidityDecimals;
 
+    mapping(address => ObservationLibrary.Observation) public observations;
+
     mapping(address => ObservationLibrary.Observation) instantRates;
 
     constructor(address quoteToken_) AbstractOracle(quoteToken_) {
         _liquidityDecimals = 0;
+    }
+
+    function getLatestObservation(
+        address token
+    ) public view virtual override returns (ObservationLibrary.Observation memory observation) {
+        return observations[token];
     }
 
     function stubSetObservation(

--- a/contracts/test/oracles/PeriodicAccumulationOracleStub.sol
+++ b/contracts/test/oracles/PeriodicAccumulationOracleStub.sol
@@ -15,8 +15,9 @@ contract PeriodicAccumulationOracleStub is PeriodicAccumulationOracle {
         address liquidityAccumulator_,
         address priceAccumulator_,
         address quoteToken_,
-        uint256 period_
-    ) PeriodicAccumulationOracle(liquidityAccumulator_, priceAccumulator_, quoteToken_, period_) {}
+        uint256 period_,
+        uint256 granularity_
+    ) PeriodicAccumulationOracle(liquidityAccumulator_, priceAccumulator_, quoteToken_, period_, granularity_) {}
 
     function stubSetObservation(
         address token,
@@ -40,7 +41,7 @@ contract PeriodicAccumulationOracleStub is PeriodicAccumulationOracle {
         uint112 cumulativeQuoteTokenLiquidity,
         uint32 timestamp
     ) public {
-        AccumulationLibrary.LiquidityAccumulator storage liquidityAccumulation = liquidityAccumulations[token];
+        /*AccumulationLibrary.LiquidityAccumulator storage liquidityAccumulation = liquidityAccumulations[token];
         AccumulationLibrary.PriceAccumulator storage priceAccumulation = priceAccumulations[token];
 
         priceAccumulation.cumulativePrice = cumulativePrice;
@@ -48,14 +49,14 @@ contract PeriodicAccumulationOracleStub is PeriodicAccumulationOracle {
 
         liquidityAccumulation.cumulativeTokenLiquidity = cumulativeTokenLiquidity;
         liquidityAccumulation.cumulativeQuoteTokenLiquidity = cumulativeQuoteTokenLiquidity;
-        liquidityAccumulation.timestamp = timestamp;
+        liquidityAccumulation.timestamp = timestamp;*/
     }
 
     function stubSetPriceAccumulation(address token, uint112 cumulativePrice, uint32 timestamp) public {
-        AccumulationLibrary.PriceAccumulator storage priceAccumulation = priceAccumulations[token];
+        /*AccumulationLibrary.PriceAccumulator storage priceAccumulation = priceAccumulations[token];
 
         priceAccumulation.cumulativePrice = cumulativePrice;
-        priceAccumulation.timestamp = timestamp;
+        priceAccumulation.timestamp = timestamp;*/
     }
 
     function stubSetLiquidityAccumulation(
@@ -64,11 +65,11 @@ contract PeriodicAccumulationOracleStub is PeriodicAccumulationOracle {
         uint112 cumulativeQuoteTokenLiquidity,
         uint32 timestamp
     ) public {
-        AccumulationLibrary.LiquidityAccumulator storage liquidityAccumulation = liquidityAccumulations[token];
+        /*AccumulationLibrary.LiquidityAccumulator storage liquidityAccumulation = liquidityAccumulations[token];
 
         liquidityAccumulation.cumulativeTokenLiquidity = cumulativeTokenLiquidity;
         liquidityAccumulation.cumulativeQuoteTokenLiquidity = cumulativeQuoteTokenLiquidity;
-        liquidityAccumulation.timestamp = timestamp;
+        liquidityAccumulation.timestamp = timestamp;*/
     }
 
     function overrideNeedsUpdate(bool overridden, bool needsUpdate_) public {

--- a/contracts/test/oracles/PeriodicAccumulationOracleStub.sol
+++ b/contracts/test/oracles/PeriodicAccumulationOracleStub.sol
@@ -19,6 +19,31 @@ contract PeriodicAccumulationOracleStub is PeriodicAccumulationOracle {
         uint256 granularity_
     ) PeriodicAccumulationOracle(liquidityAccumulator_, priceAccumulator_, quoteToken_, period_, granularity_) {}
 
+    function stubPush(
+        address token,
+        uint224 cumulativePrice,
+        uint32 priceTimestamp,
+        uint112 cumulativeTokenLiquidity,
+        uint112 cumulativeQuoteTokenLiquidity,
+        uint32 liquidityTimestamp
+    ) public {
+        AccumulationLibrary.PriceAccumulator memory priceAccumulation;
+        AccumulationLibrary.LiquidityAccumulator memory liquidityAccumulation;
+
+        priceAccumulation.cumulativePrice = cumulativePrice;
+        priceAccumulation.timestamp = priceTimestamp;
+
+        liquidityAccumulation.cumulativeTokenLiquidity = cumulativeTokenLiquidity;
+        liquidityAccumulation.cumulativeQuoteTokenLiquidity = cumulativeQuoteTokenLiquidity;
+        liquidityAccumulation.timestamp = liquidityTimestamp;
+
+        push(token, priceAccumulation, liquidityAccumulation);
+    }
+
+    function stubInitializeBuffers(address token) public {
+        initializeBuffers(token);
+    }
+
     function priceAccumulations(address token) public view returns (AccumulationLibrary.PriceAccumulator memory) {
         return priceAccumulationBuffers[token][accumulationBufferMetadata[token].end];
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrastia-oracle/adrastia-core",
-  "version": "2.0.0",
+  "version": "3.0.0-beta.1",
   "main": "index.js",
   "author": "TRILEZ SOFTWARE INC.",
   "license": "MIT",

--- a/scripts/consult-aggregate.js
+++ b/scripts/consult-aggregate.js
@@ -39,7 +39,7 @@ async function createContract(name, ...deploymentArgs) {
     return contract;
 }
 
-async function createUniswapV2Oracle(factory, initCodeHash, quoteToken, liquidityDecimals, period) {
+async function createUniswapV2Oracle(factory, initCodeHash, quoteToken, liquidityDecimals, period, granularity) {
     const updateTheshold = 2000000; // 2% change -> update
     const minUpdateDelay = 5; // At least 5 seconds between every update
     const maxUpdateDelay = 10; // At most (optimistically) 60 seconds between every update
@@ -70,7 +70,8 @@ async function createUniswapV2Oracle(factory, initCodeHash, quoteToken, liquidit
         liquidityAccumulator.address,
         priceAccumulator.address,
         quoteToken,
-        period
+        period,
+        granularity
     );
 
     return {
@@ -80,7 +81,7 @@ async function createUniswapV2Oracle(factory, initCodeHash, quoteToken, liquidit
     };
 }
 
-async function createUniswapV3Oracle(factory, initCodeHash, quoteToken, liquidityDecimals, period) {
+async function createUniswapV3Oracle(factory, initCodeHash, quoteToken, liquidityDecimals, period, granularity) {
     const poolFees = [/*500, */ 3000 /*, 10000*/];
 
     const updateTheshold = 2000000; // 2% change -> update
@@ -115,7 +116,8 @@ async function createUniswapV3Oracle(factory, initCodeHash, quoteToken, liquidit
         liquidityAccumulator.address,
         priceAccumulator.address,
         quoteToken,
-        period
+        period,
+        granularity
     );
 
     return {
@@ -132,6 +134,7 @@ async function createAggregatedOracle(
     quoteTokenDecimals,
     liquidityDecimals,
     period,
+    granularity,
     oracles,
     tokenSpecificOracles
 ) {
@@ -145,6 +148,7 @@ async function createAggregatedOracle(
         oracles,
         tokenSpecificOracles,
         period,
+        granularity,
         1,
         10 ** quoteTokenDecimals // minimum is one whole token
     );
@@ -156,6 +160,7 @@ async function main() {
 
     const underlyingPeriodSeconds = 10;
     const periodSeconds = 10;
+    const granularity = 1;
 
     const liquidityDecimals = 4;
 
@@ -164,21 +169,24 @@ async function main() {
         uniswapV2InitCodeHash,
         quoteToken,
         liquidityDecimals,
-        underlyingPeriodSeconds
+        underlyingPeriodSeconds,
+        granularity
     );
     const sushiswap = await createUniswapV2Oracle(
         sushiswapFactoryAddress,
         sushiswapInitCodeHash,
         quoteToken,
         liquidityDecimals,
-        underlyingPeriodSeconds
+        underlyingPeriodSeconds,
+        granularity
     );
     const uniswapV3 = await createUniswapV3Oracle(
         uniswapV3FactoryAddress,
         uniswapV3InitCodeHash,
         quoteToken,
         liquidityDecimals,
-        underlyingPeriodSeconds
+        underlyingPeriodSeconds,
+        granularity
     );
 
     const oracles = [uniswapV2.oracle.address, sushiswap.oracle.address, uniswapV3.oracle.address];
@@ -192,6 +200,7 @@ async function main() {
         6,
         liquidityDecimals,
         periodSeconds,
+        granularity,
         oracles,
         tokenSpecificOracles
     );

--- a/scripts/consult-curve-steth.js
+++ b/scripts/consult-curve-steth.js
@@ -27,7 +27,7 @@ async function createContract(name, ...deploymentArgs) {
     return contract;
 }
 
-async function createCurveOracle(pool, poolQuoteToken, ourQuoteToken, period, liquidityDecimals) {
+async function createCurveOracle(pool, poolQuoteToken, ourQuoteToken, period, granularity, liquidityDecimals) {
     const updateTheshold = 2000000; // 2% change -> update
     const minUpdateDelay = 5; // At least 5 seconds between every update
     const maxUpdateDelay = 60; // At most (optimistically) 60 seconds between every update
@@ -60,7 +60,8 @@ async function createCurveOracle(pool, poolQuoteToken, ourQuoteToken, period, li
         liquidityAccumulator.address,
         priceAccumulator.address,
         ourQuoteToken,
-        period
+        period,
+        granularity
     );
 
     return {
@@ -79,10 +80,18 @@ async function main() {
     const ourQuoteToken = wethAddress;
 
     const period = 10; // 10 seconds
+    const granularity = 1;
 
     const liquidityDecimals = 4;
 
-    const curve = await createCurveOracle(poolAddress, poolQuoteToken, ourQuoteToken, period, liquidityDecimals);
+    const curve = await createCurveOracle(
+        poolAddress,
+        poolQuoteToken,
+        ourQuoteToken,
+        period,
+        granularity,
+        liquidityDecimals
+    );
 
     const tokenContract = await ethers.getContractAt("ERC20", token);
     const quoteTokenContract = await ethers.getContractAt("ERC20", ourQuoteToken);

--- a/scripts/consult-curve-tricrypto2.js
+++ b/scripts/consult-curve-tricrypto2.js
@@ -28,7 +28,7 @@ async function createContract(name, ...deploymentArgs) {
     return contract;
 }
 
-async function createCurveOracle(pool, poolQuoteToken, ourQuoteToken, period, liquidityDecimals) {
+async function createCurveOracle(pool, poolQuoteToken, ourQuoteToken, period, granularity, liquidityDecimals) {
     const updateTheshold = 2000000; // 2% change -> update
     const minUpdateDelay = 5; // At least 5 seconds between every update
     const maxUpdateDelay = 60; // At most (optimistically) 60 seconds between every update
@@ -61,7 +61,8 @@ async function createCurveOracle(pool, poolQuoteToken, ourQuoteToken, period, li
         liquidityAccumulator.address,
         priceAccumulator.address,
         ourQuoteToken,
-        period
+        period,
+        granularity
     );
 
     return {
@@ -80,10 +81,18 @@ async function main() {
     const ourQuoteToken = usdtAddress;
 
     const period = 10; // 10 seconds
+    const granularity = 1;
 
     const liquidityDecimals = 4;
 
-    const curve = await createCurveOracle(poolAddress, poolQuoteToken, ourQuoteToken, period, liquidityDecimals);
+    const curve = await createCurveOracle(
+        poolAddress,
+        poolQuoteToken,
+        ourQuoteToken,
+        period,
+        granularity,
+        liquidityDecimals
+    );
 
     const tokenContract = await ethers.getContractAt("ERC20", token);
     const quoteTokenContract = await ethers.getContractAt("ERC20", ourQuoteToken);

--- a/scripts/consult-uniswap-v3.js
+++ b/scripts/consult-uniswap-v3.js
@@ -27,7 +27,7 @@ async function createContract(name, ...deploymentArgs) {
     return contract;
 }
 
-async function createUniswapV3Oracle(factory, initCodeHash, quoteToken, period, liquidityDecimals) {
+async function createUniswapV3Oracle(factory, initCodeHash, quoteToken, period, granularity, liquidityDecimals) {
     const poolFees = [/*500, */ 3000 /*, 10000*/];
 
     const updateTheshold = 2000000; // 2% change -> update
@@ -62,7 +62,8 @@ async function createUniswapV3Oracle(factory, initCodeHash, quoteToken, period, 
         liquidityAccumulator.address,
         priceAccumulator.address,
         quoteToken,
-        period
+        period,
+        granularity
     );
 
     return {
@@ -77,6 +78,7 @@ async function main() {
     const quoteToken = usdcAddress;
 
     const underlyingPeriodSeconds = 5;
+    const granularity = 1;
 
     const liquidityDecimals = 4;
 
@@ -85,6 +87,7 @@ async function main() {
         uniswapV3InitCodeHash,
         quoteToken,
         underlyingPeriodSeconds,
+        granularity,
         liquidityDecimals
     );
 

--- a/test/oracles/aggregated-oracle.js
+++ b/test/oracles/aggregated-oracle.js
@@ -3226,6 +3226,12 @@ describe("AggregatedOracle - IHistoricalOracle implementation", function () {
 
             await expect(oracle.stubInitializeBuffers(GRT)).to.be.revertedWith("AggregatedOracle: ALREADY_INITIALIZED");
         });
+
+        it("Emits the correct event", async function () {
+            await expect(oracle.stubInitializeBuffers(GRT))
+                .to.emit(oracle, "ObservationCapacityInitialized")
+                .withArgs(GRT, GRANULARITY);
+        });
     });
 
     describe("AggregatedOracle#setObservationCapacity", function () {

--- a/test/oracles/aggregated-oracle.js
+++ b/test/oracles/aggregated-oracle.js
@@ -9,6 +9,7 @@ const GRT = "0xc944E90C64B2c07662A292be6244BDf05Cda44a7";
 const BAT = "0x0D8775F648430679A709E98d2b0Cb6250d2887EF";
 
 const PERIOD = 100;
+const GRANULARITY = 1;
 const MINIMUM_TOKEN_LIQUIDITY_VALUE = BigNumber.from(0);
 const MINIMUM_QUOTE_TOKEN_LIQUIDITY = BigNumber.from(0);
 
@@ -86,6 +87,7 @@ describe("AggregatedOracle#constructor", async function () {
         const oracles = [oracle1.address];
         const tokenSpecificOracles = [grtOracle];
         const period = 30;
+        const granularity = 5;
         const minimumTokenLiquidityValue = BigNumber.from(1);
         const minimumQuoteTokenLiquidity = BigNumber.from(2);
 
@@ -98,6 +100,7 @@ describe("AggregatedOracle#constructor", async function () {
             oracles,
             tokenSpecificOracles,
             period,
+            granularity,
             minimumTokenLiquidityValue,
             minimumQuoteTokenLiquidity
         );
@@ -109,6 +112,7 @@ describe("AggregatedOracle#constructor", async function () {
         expect(await oracle.liquidityDecimals()).to.equal(liquidityDecimals);
         expect(await oracle.getOracles()).to.eql(oracles); // eql = deep equality
         expect(await oracle.period()).to.equal(period);
+        expect(await oracle.granularity()).to.equal(granularity);
         expect(await oracle.minimumTokenLiquidityValue()).to.equal(minimumTokenLiquidityValue);
         expect(await oracle.minimumQuoteTokenLiquidity()).to.equal(minimumQuoteTokenLiquidity);
 
@@ -128,6 +132,7 @@ describe("AggregatedOracle#constructor", async function () {
                 [],
                 [],
                 PERIOD,
+                GRANULARITY,
                 MINIMUM_TOKEN_LIQUIDITY_VALUE,
                 MINIMUM_QUOTE_TOKEN_LIQUIDITY
             )
@@ -148,6 +153,7 @@ describe("AggregatedOracle#constructor", async function () {
                 [oracle1.address, oracle1.address],
                 [],
                 PERIOD,
+                GRANULARITY,
                 MINIMUM_TOKEN_LIQUIDITY_VALUE,
                 MINIMUM_QUOTE_TOKEN_LIQUIDITY
             )
@@ -173,6 +179,7 @@ describe("AggregatedOracle#constructor", async function () {
                 [],
                 [oracle1Config, oracle1Config],
                 PERIOD,
+                GRANULARITY,
                 MINIMUM_TOKEN_LIQUIDITY_VALUE,
                 MINIMUM_QUOTE_TOKEN_LIQUIDITY
             )
@@ -198,6 +205,7 @@ describe("AggregatedOracle#constructor", async function () {
                 [oracle1.address],
                 [oracle1Config],
                 PERIOD,
+                GRANULARITY,
                 MINIMUM_TOKEN_LIQUIDITY_VALUE,
                 MINIMUM_QUOTE_TOKEN_LIQUIDITY
             )
@@ -224,6 +232,7 @@ describe("AggregatedOracle#needsUpdate", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -306,6 +315,7 @@ describe("AggregatedOracle#canUpdate", function () {
             [underlyingOracle1.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -388,6 +398,7 @@ describe("AggregatedOracle#consultPrice(token)", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -442,6 +453,7 @@ describe("AggregatedOracle#consultPrice(token, maxAge = 0)", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -479,6 +491,7 @@ describe("AggregatedOracle#consultPrice(token, maxAge)", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -636,6 +649,7 @@ describe("AggregatedOracle#consultLiquidity(token)", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -694,6 +708,7 @@ describe("AggregatedOracle#consultLiquidity(token, maxAge = 0)", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -765,6 +780,7 @@ describe("AggregatedOracle#consultLiquidity(token, maxAge)", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -942,6 +958,7 @@ describe("AggregatedOracle#consult(token)", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -1004,6 +1021,7 @@ describe("AggregatedOracle#consult(token, maxAge = 0)", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -1042,6 +1060,7 @@ describe("AggregatedOracle#consult(token, maxAge = 0)", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -1076,6 +1095,7 @@ describe("AggregatedOracle#consult(token, maxAge = 0)", function () {
             [underlyingOracle.address, underlyingOracle2.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -1111,6 +1131,7 @@ describe("AggregatedOracle#consult(token, maxAge = 0)", function () {
             [underlyingOracle.address, underlyingOracle2.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -1146,6 +1167,7 @@ describe("AggregatedOracle#consult(token, maxAge = 0)", function () {
             [underlyingOracle.address, underlyingOracle2.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -1248,6 +1270,7 @@ describe("AggregatedOracle#consult(token, maxAge)", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -1377,6 +1400,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -1406,7 +1430,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(tokenLiquidity);
@@ -1440,7 +1464,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(tokenLiquidity);
@@ -1472,7 +1496,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             .to.emit(oracle, "Updated")
             .withArgs(token, expectedPrice, tokenLiquidity, quoteTokenLiquidity, timestamp);
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(expectedPrice);
         expect(oTokenLiquidity).to.equal(tokenLiquidity);
@@ -1504,7 +1528,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             .to.emit(oracle, "Updated")
             .withArgs(token, expectedPrice, tokenLiquidity, quoteTokenLiquidity, timestamp);
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(expectedPrice);
         expect(oTokenLiquidity).to.equal(tokenLiquidity);
@@ -1537,7 +1561,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             .to.emit(oracle, "Updated")
             .withArgs(token, price, expectedTokenLiquidity, expectedQuoteTokenLiquidity, timestamp);
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(expectedTokenLiquidity);
@@ -1570,7 +1594,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             .to.emit(oracle, "Updated")
             .withArgs(token, price, expectedTokenLiquidity, expectedQuoteTokenLiquidity, timestamp);
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(expectedTokenLiquidity);
@@ -1584,7 +1608,9 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
         const quoteTokenLiquidity = ethers.utils.parseUnits("1", 18);
         const timestamp = (await currentBlockTimestamp()) + PERIOD * 2 + 1;
 
-        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.observations(token);
+        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.getLatestObservation(
+            token
+        );
 
         await underlyingOracle.stubSetObservation(
             token,
@@ -1607,7 +1633,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(poPrice);
         expect(oTokenLiquidity).to.equal(poTokenLiquidity);
@@ -1621,7 +1647,9 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
         const quoteTokenLiquidity = ethers.utils.parseUnits("1", 18);
         const timestamp = (await currentBlockTimestamp()) + 10;
 
-        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.observations(token);
+        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.getLatestObservation(
+            token
+        );
 
         await underlyingOracle.stubSetObservation(
             token,
@@ -1656,7 +1684,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(poPrice);
         expect(oTokenLiquidity).to.equal(poTokenLiquidity);
@@ -1690,7 +1718,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
                 "0x4e487b710000000000000000000000000000000000000000000000000000000000000011"
             );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(tokenLiquidity);
@@ -1720,7 +1748,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             .to.emit(oracle, "UpdateErrorWithReason")
             .withArgs(underlyingOracle.address, token, "REASON");
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(tokenLiquidity);
@@ -1731,7 +1759,9 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
     it("Shouldn't update when there aren't any valid consultations", async () => {
         const timestamp = (await currentBlockTimestamp()) + 10;
 
-        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.observations(token);
+        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.getLatestObservation(
+            token
+        );
 
         await hre.timeAndMine.setTimeNextBlock(timestamp);
 
@@ -1743,7 +1773,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(poPrice);
         expect(oTokenLiquidity).to.equal(poTokenLiquidity);
@@ -1765,7 +1795,9 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             await currentBlockTimestamp()
         );
 
-        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.observations(token);
+        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.getLatestObservation(
+            token
+        );
 
         await hre.timeAndMine.setTimeNextBlock(timestamp);
 
@@ -1777,7 +1809,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(poPrice);
         expect(oTokenLiquidity).to.equal(poTokenLiquidity);
@@ -1799,7 +1831,9 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             await currentBlockTimestamp()
         );
 
-        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.observations(token);
+        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.getLatestObservation(
+            token
+        );
 
         await hre.timeAndMine.setTimeNextBlock(timestamp);
 
@@ -1811,7 +1845,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(poPrice);
         expect(oTokenLiquidity).to.equal(poTokenLiquidity);
@@ -1833,7 +1867,9 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             await currentBlockTimestamp()
         );
 
-        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.observations(token);
+        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.getLatestObservation(
+            token
+        );
 
         await hre.timeAndMine.setTimeNextBlock(timestamp);
 
@@ -1845,7 +1881,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle", function () {
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(poPrice);
         expect(oTokenLiquidity).to.equal(poTokenLiquidity);
@@ -1885,6 +1921,7 @@ describe("AggregatedOracle#update w/ 2 underlying oracle", function () {
             [underlyingOracle1.address, underlyingOracle2.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -1930,7 +1967,7 @@ describe("AggregatedOracle#update w/ 2 underlying oracle", function () {
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice, "Observation price").to.equal(price);
         expect(oTokenLiquidity, "Observation token liquidity").to.equal(totalTokenLiquidity);
@@ -1976,7 +2013,7 @@ describe("AggregatedOracle#update w/ 2 underlying oracle", function () {
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(totalTokenLiquidity);
@@ -2030,7 +2067,7 @@ describe("AggregatedOracle#update w/ 2 underlying oracle", function () {
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(expectedPrice);
         expect(oTokenLiquidity).to.equal(totalTokenLiquidity);
@@ -2075,6 +2112,7 @@ describe("AggregatedOracle#update w/ 1 general underlying oracle and one token s
                 },
             ],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -2118,7 +2156,7 @@ describe("AggregatedOracle#update w/ 1 general underlying oracle and one token s
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(totalTokenLiquidity);
@@ -2163,7 +2201,7 @@ describe("AggregatedOracle#update w/ 1 general underlying oracle and one token s
             BigNumber.from(0)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(tokenLiquidity);
@@ -2203,6 +2241,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle and a minimum token liq
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             minimumTokenLiquidityValue,
             minimumQuoteTokenLiquidity
         );
@@ -2226,7 +2265,9 @@ describe("AggregatedOracle#update w/ 1 underlying oracle and a minimum token liq
             await currentBlockTimestamp()
         );
 
-        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.observations(token);
+        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.getLatestObservation(
+            token
+        );
 
         await hre.timeAndMine.setTimeNextBlock(timestamp);
 
@@ -2238,7 +2279,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle and a minimum token liq
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(poPrice);
         expect(oTokenLiquidity).to.equal(poTokenLiquidity);
@@ -2270,7 +2311,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle and a minimum token liq
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(tokenLiquidity);
@@ -2310,6 +2351,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle and a minimum quote tok
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             minimumTokenLiquidityValue,
             minimumQuoteTokenLiquidity
         );
@@ -2333,7 +2375,9 @@ describe("AggregatedOracle#update w/ 1 underlying oracle and a minimum quote tok
             await currentBlockTimestamp()
         );
 
-        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.observations(token);
+        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.getLatestObservation(
+            token
+        );
 
         await hre.timeAndMine.setTimeNextBlock(timestamp);
 
@@ -2345,7 +2389,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle and a minimum quote tok
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(poPrice);
         expect(oTokenLiquidity).to.equal(poTokenLiquidity);
@@ -2377,7 +2421,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle and a minimum quote tok
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(tokenLiquidity);
@@ -2414,6 +2458,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle and an allowed TVL dist
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -2438,7 +2483,9 @@ describe("AggregatedOracle#update w/ 1 underlying oracle and an allowed TVL dist
             await currentBlockTimestamp()
         );
 
-        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.observations(token);
+        const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.getLatestObservation(
+            token
+        );
 
         await hre.timeAndMine.setTimeNextBlock(timestamp);
 
@@ -2450,7 +2497,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle and an allowed TVL dist
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(poPrice);
         expect(oTokenLiquidity).to.equal(poTokenLiquidity);
@@ -2483,7 +2530,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle and an allowed TVL dist
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(tokenLiquidity);
@@ -2516,7 +2563,7 @@ describe("AggregatedOracle#update w/ 1 underlying oracle and an allowed TVL dist
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(tokenLiquidity);
@@ -2557,6 +2604,7 @@ describe("AggregatedOracle#update w/ 2 underlying oracles but one failing valida
             [underlyingOracle1.address, underlyingOracle2.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -2608,7 +2656,7 @@ describe("AggregatedOracle#update w/ 2 underlying oracles but one failing valida
             BigNumber.from(1)
         );
 
-        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.observations(token);
+        const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(token);
 
         expect(oPrice).to.equal(price);
         expect(oTokenLiquidity).to.equal(totalTokenLiquidity);
@@ -2658,6 +2706,7 @@ describe("AggregatedOracle#sanityCheckQuoteTokenLiquidity", function () {
                     [underlyingOracle.address],
                     [],
                     PERIOD,
+                    GRANULARITY,
                     MINIMUM_TOKEN_LIQUIDITY_VALUE,
                     minimumQuoteTokenLiquidity
                 );
@@ -2775,6 +2824,7 @@ describe("AggregatedOracle#sanityCheckTokenLiquidityValue", function () {
                                     [underlyingOracle.address],
                                     [],
                                     PERIOD,
+                                    GRANULARITY,
                                     minimumTokenLiquidityValue,
                                     MINIMUM_QUOTE_TOKEN_LIQUIDITY
                                 );
@@ -2843,6 +2893,7 @@ describe("AggregatedOracle#sanityCheckTvlDistributionRatio", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -2956,6 +3007,7 @@ describe("AggregatedOracle#validateUnderlyingConsultation", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -3042,6 +3094,7 @@ describe("AggregatedOracle#calculateMaxAge", function () {
             [underlyingOracle.address],
             [],
             1, // period
+            GRANULARITY,
             0,
             0
         );
@@ -3062,6 +3115,7 @@ describe("AggregatedOracle#calculateMaxAge", function () {
                 [underlyingOracle.address],
                 [],
                 period, // period
+                GRANULARITY,
                 0,
                 0
             );
@@ -3092,6 +3146,7 @@ describe("AggregatedOracle#supportsInterface(interfaceId)", function () {
             [underlyingOracle.address],
             [],
             PERIOD,
+            GRANULARITY,
             MINIMUM_TOKEN_LIQUIDITY_VALUE,
             MINIMUM_QUOTE_TOKEN_LIQUIDITY
         );
@@ -3130,6 +3185,11 @@ describe("AggregatedOracle#supportsInterface(interfaceId)", function () {
 
     it("Should support IUpdateable", async () => {
         const interfaceId = await interfaceIds.iUpdateable();
+        expect(await oracle["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
+    });
+
+    it("Should support IHistoricalOracle", async () => {
+        const interfaceId = await interfaceIds.iHistoricalOracle();
         expect(await oracle["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
     });
 });

--- a/test/oracles/aggregated-oracle.js
+++ b/test/oracles/aggregated-oracle.js
@@ -3630,6 +3630,9 @@ describe("AggregatedOracle - IHistoricalOracle implementation", function () {
                 await oracle.stubPush(GRT, i, i, i, i);
             }
 
+            // Sanity check the count
+            expect(await oracle.getObservationsCount(GRT)).to.equal(Math.min(observationsToPush, capacity));
+
             const observations = await oracle["getObservations(address,uint256,uint256,uint256)"](
                 GRT,
                 amountToGet,
@@ -3787,6 +3790,9 @@ describe("AggregatedOracle - IHistoricalOracle implementation", function () {
                 await oracle.stubPush(GRT, i, i, i, i);
             }
 
+            // Sanity check the count
+            expect(await oracle.getObservationsCount(GRT)).to.equal(Math.min(observationsToPush, capacity));
+
             const observations = await oracle["getObservations(address,uint256)"](GRT, amountToGet);
 
             expect(observations.length).to.equal(amountToGet);
@@ -3816,11 +3822,17 @@ describe("AggregatedOracle - IHistoricalOracle implementation", function () {
 
     describe("AggregatedOracle#getObservationAt", function () {
         it("Should revert if the buffer is uninitialized", async function () {
+            // Sanity check the observations count
+            expect(await oracle.getObservationsCount(GRT)).to.equal(0);
+
             await expect(oracle.getObservationAt(GRT, 0)).to.be.revertedWith("AggregatedOracle: INVALID_INDEX");
         });
 
         it("Should revert if the buffer is initialized but empty", async function () {
             await oracle.stubInitializeBuffers(GRT);
+
+            // Sanity check the observations count
+            expect(await oracle.getObservationsCount(GRT)).to.equal(0);
 
             await expect(oracle.getObservationAt(GRT, 0)).to.be.revertedWith("AggregatedOracle: INVALID_INDEX");
         });
@@ -3835,6 +3847,9 @@ describe("AggregatedOracle - IHistoricalOracle implementation", function () {
                 await oracle.stubPush(GRT, 1, 1, 1, 1);
             }
 
+            // Sanity check the observations count
+            expect(await oracle.getObservationsCount(GRT)).to.equal(capacity);
+
             await expect(oracle.getObservationAt(GRT, capacity)).to.be.revertedWith("AggregatedOracle: INVALID_INDEX");
         });
 
@@ -3848,6 +3863,9 @@ describe("AggregatedOracle - IHistoricalOracle implementation", function () {
                 await oracle.stubPush(GRT, 1, 1, 1, 1);
             }
 
+            // Sanity check the observations count
+            expect(await oracle.getObservationsCount(GRT)).to.equal(capacity - 1);
+
             await expect(oracle.getObservationAt(GRT, capacity - 1)).to.be.revertedWith(
                 "AggregatedOracle: INVALID_INDEX"
             );
@@ -3859,6 +3877,9 @@ describe("AggregatedOracle - IHistoricalOracle implementation", function () {
             // Push capacity observations
             await oracle.stubPush(GRT, 1, 1, 1, 1);
             await oracle.stubPush(GRT, 2, 2, 2, 2);
+
+            // Sanity check the observations count
+            expect(await oracle.getObservationsCount(GRT)).to.equal(2);
 
             const observation = await oracle.getObservationAt(GRT, 0);
 
@@ -3876,6 +3897,9 @@ describe("AggregatedOracle - IHistoricalOracle implementation", function () {
             await oracle.stubPush(GRT, 2, 2, 2, 2);
             await oracle.stubPush(GRT, 3, 3, 3, 3);
 
+            // Sanity check the observations count
+            expect(await oracle.getObservationsCount(GRT)).to.equal(2);
+
             const observation = await oracle.getObservationAt(GRT, 0);
 
             expect(observation.price).to.equal(3);
@@ -3892,6 +3916,9 @@ describe("AggregatedOracle - IHistoricalOracle implementation", function () {
             await oracle.stubPush(GRT, 2, 2, 2, 2);
             await oracle.stubPush(GRT, 3, 3, 3, 3);
 
+            // Sanity check the observations count
+            expect(await oracle.getObservationsCount(GRT)).to.equal(2);
+
             const observation = await oracle.getObservationAt(GRT, 1);
 
             expect(observation.price).to.equal(2);
@@ -3906,6 +3933,9 @@ describe("AggregatedOracle - IHistoricalOracle implementation", function () {
             // Push capacity observations
             await oracle.stubPush(GRT, 1, 1, 1, 1);
             await oracle.stubPush(GRT, 2, 2, 2, 2);
+
+            // Sanity check the observations count
+            expect(await oracle.getObservationsCount(GRT)).to.equal(2);
 
             const observation = await oracle.getObservationAt(GRT, 1);
 

--- a/test/oracles/aggregated-oracle.js
+++ b/test/oracles/aggregated-oracle.js
@@ -3193,3 +3193,726 @@ describe("AggregatedOracle#supportsInterface(interfaceId)", function () {
         expect(await oracle["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
     });
 });
+
+describe("AggregatedOracle - IHistoricalOracle implementation", function () {
+    var oracle;
+    var underlyingOracle;
+
+    beforeEach(async () => {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("AggregatedOracleStub");
+
+        underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        oracle = await oracleFactory.deploy(
+            "USD Coin",
+            USDC,
+            "USDC",
+            6, // quote token decimals
+            0, // liquidity decimals
+            [underlyingOracle.address],
+            [],
+            PERIOD,
+            GRANULARITY,
+            MINIMUM_TOKEN_LIQUIDITY_VALUE,
+            MINIMUM_QUOTE_TOKEN_LIQUIDITY
+        );
+    });
+
+    describe("AggregatedOracle#initializeBuffers", function () {
+        it("Can't be called twice", async function () {
+            await oracle.stubInitializeBuffers(GRT);
+
+            await expect(oracle.stubInitializeBuffers(GRT)).to.be.revertedWith("AggregatedOracle: ALREADY_INITIALIZED");
+        });
+    });
+
+    describe("AggregatedOracle#setObservationCapacity", function () {
+        it("Should revert if the amount is less than the existing capacity", async function () {
+            await oracle.setObservationsCapacity(GRT, 4);
+
+            await expect(oracle.setObservationsCapacity(GRT, 2)).to.be.revertedWith(
+                "AggregatedOracle: CAPACITY_CANNOT_BE_DECREASED"
+            );
+        });
+
+        it("Should revert if the amount is 0", async function () {
+            await expect(oracle.setObservationsCapacity(GRT, 0)).to.be.revertedWith(
+                "AggregatedOracle: CAPACITY_CANNOT_BE_DECREASED"
+            );
+        });
+
+        it("Should revert if the amount is larger than the maximum capacity", async function () {
+            await expect(oracle.setObservationsCapacity(GRT, 65536)).to.be.revertedWith(
+                "AggregatedOracle: CAPACITY_TOO_LARGE"
+            );
+        });
+
+        it("Should emit an event when the capacity is changed", async function () {
+            const amount = 20;
+
+            const initialAmount = await oracle.getObservationsCapacity(GRT);
+
+            // Sanity check that the new amount is greater than the initial amount
+            expect(amount).to.be.greaterThan(initialAmount.toNumber());
+
+            await expect(oracle.setObservationsCapacity(GRT, amount))
+                .to.emit(oracle, "ObservationCapacityIncreased")
+                .withArgs(GRT, initialAmount, amount);
+        });
+
+        it("Should not emit an event when the capacity is not changed (with default capacity)", async function () {
+            const initialAmount = await oracle.getObservationsCapacity(GRT);
+
+            await expect(oracle.setObservationsCapacity(GRT, initialAmount)).to.not.emit(
+                oracle,
+                "ObservationCapacityIncreased"
+            );
+        });
+
+        it("Should not emit an event when the capacity is not changed (with non-default capacity)", async function () {
+            const initialAmount = await oracle.getObservationsCapacity(GRT);
+            const amount = 20;
+
+            // Sanity check that the new amount is greater than the initial amount
+            expect(amount).to.be.greaterThan(initialAmount.toNumber());
+
+            await oracle.setObservationsCapacity(GRT, amount);
+
+            // Sanity check that the capacity is now the new amount
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(amount);
+
+            // Try again to set it to the same amount
+            await expect(oracle.setObservationsCapacity(GRT, amount)).to.not.emit(
+                oracle,
+                "ObservationCapacityIncreased"
+            );
+        });
+
+        it("Should update the capacity", async function () {
+            const amount = 20;
+
+            // Sanity check that the new amount is greater than the initial amount
+            expect(amount).to.be.greaterThan((await oracle.getObservationsCapacity(GRT)).toNumber());
+
+            await oracle.setObservationsCapacity(GRT, amount);
+
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(amount);
+        });
+
+        it("Added capacity should not be filled until our latest observation is beside an uninitialized observation", async function () {
+            const workingCapacity = 6;
+
+            // Set the capacity to the working capacity
+            await oracle.setObservationsCapacity(GRT, workingCapacity);
+
+            // Push workingCapacity + 1 observations so that the buffer is full and the latest observation is at the start of the buffer
+            for (let i = 0; i < workingCapacity + 1; ++i) {
+                await oracle.stubPush(GRT, 1, 1, 1, 1);
+            }
+
+            // Sanity check that the buffer is full
+            expect(await oracle.getObservationsCount(GRT)).to.equal(workingCapacity);
+
+            // Increase the capacity by 1
+            await oracle.setObservationsCapacity(GRT, workingCapacity + 1);
+
+            // We should need to push workingCapacity observations before the new capacity is filled
+            for (let i = 0; i < workingCapacity - 1; ++i) {
+                await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+                // Sanity check that the buffer is still not full
+                expect(await oracle.getObservationsCount(GRT)).to.equal(workingCapacity);
+            }
+
+            // Push one more observation. This should fill the new capacity
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+            // Check that the buffer is now full
+            expect(await oracle.getObservationsCount(GRT)).to.equal(workingCapacity + 1);
+        });
+    });
+
+    describe("AggregatedOracle#getObservationsCapacity", function () {
+        it("Should return the default capacity when the buffer is uninitialized", async function () {
+            const initialCapacity = await oracle.stubInitialCardinality();
+
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(initialCapacity);
+        });
+
+        it("Should return the capacity when the buffer is initialized", async function () {
+            await oracle.stubInitializeBuffers(GRT);
+
+            const initialCapacity = await oracle.stubInitialCardinality();
+
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(initialCapacity);
+        });
+
+        it("Should return the capacity after the buffer has been resized", async function () {
+            const amount = 20;
+
+            // Sanity check that the new amount is greater than the initial amount
+            expect(amount).to.be.greaterThan((await oracle.getObservationsCapacity(GRT)).toNumber());
+
+            await oracle.setObservationsCapacity(GRT, amount);
+
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(amount);
+        });
+    });
+
+    describe("AggregatedOracle#getObservationsCount", function () {
+        it("Should return 0 when the buffer is uninitialized", async function () {
+            expect(await oracle.getObservationsCount(GRT)).to.equal(0);
+        });
+
+        it("Should return 0 when the buffer is initialized but empty", async function () {
+            await oracle.stubInitializeBuffers(GRT);
+
+            expect(await oracle.getObservationsCount(GRT)).to.equal(0);
+        });
+
+        it("Increasing capacity should not change the observations count", async function () {
+            const initialAmount = 4;
+
+            await oracle.setObservationsCapacity(GRT, initialAmount);
+
+            // Push 2 observations
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+            // Sanity check that the observations count is 2
+            expect(await oracle.getObservationsCount(GRT)).to.equal(2);
+
+            // Increase the capacity by 1
+            await oracle.setObservationsCapacity(GRT, initialAmount + 1);
+
+            // The observations count should still be 2
+            expect(await oracle.getObservationsCount(GRT)).to.equal(2);
+        });
+
+        it("Should be limited by the capacity", async function () {
+            const capacity = 6;
+
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Push capacity + 1 observations
+            for (let i = 0; i < capacity + 1; ++i) {
+                await oracle.stubPush(GRT, 1, 1, 1, 1);
+            }
+
+            // The observations count should be limited by the capacity
+            expect(await oracle.getObservationsCount(GRT)).to.equal(capacity);
+        });
+    });
+
+    describe("AggregatedOracle#getObservations(token, amount, offset, increment)", function () {
+        it("Should return an empty array when amount is 0", async function () {
+            // Push 1 observation
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+            const observations = await oracle["getObservations(address,uint256,uint256,uint256)"](GRT, 0, 0, 1);
+
+            expect(observations.length).to.equal(0);
+        });
+
+        it("Should revert if the offset equals the number of observations", async function () {
+            // Push 1 observation
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+            await expect(oracle["getObservations(address,uint256,uint256,uint256)"](GRT, 1, 1, 1)).to.be.revertedWith(
+                "AggregatedOracle: INSUFFICIENT_DATA"
+            );
+        });
+
+        it("Should revert if the offset equals the number of observations but is less than the capacity", async function () {
+            const capacity = 6;
+
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Sanity check the capacity
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(capacity);
+
+            // Push 1 observation
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+            await expect(oracle["getObservations(address,uint256,uint256,uint256)"](GRT, 1, 1, 1)).to.be.revertedWith(
+                "AggregatedOracle: INSUFFICIENT_DATA"
+            );
+        });
+
+        it("Should revert if the amount exceeds the number of observations", async function () {
+            // Push 1 observation
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+            await expect(oracle["getObservations(address,uint256,uint256,uint256)"](GRT, 2, 0, 1)).to.be.revertedWith(
+                "AggregatedOracle: INSUFFICIENT_DATA"
+            );
+        });
+
+        it("Should revert if the amount exceeds the number of observations but is less than the capacity", async function () {
+            const capacity = 6;
+            const amountToGet = 2;
+
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Sanity check the capacity
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(capacity);
+
+            // Push 1 observation
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+            // Sanity check that the amount to get is less than the capacity
+            expect(amountToGet).to.be.lessThan(capacity);
+
+            await expect(
+                oracle["getObservations(address,uint256,uint256,uint256)"](GRT, amountToGet, 0, 1)
+            ).to.be.revertedWith("AggregatedOracle: INSUFFICIENT_DATA");
+        });
+
+        it("Should revert if the amount and offset exceed the number of observations", async function () {
+            const capacity = 2;
+            const amountToGet = 2;
+
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Sanity check the capacity
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(capacity);
+
+            // Push 2 observation
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+            await expect(
+                oracle["getObservations(address,uint256,uint256,uint256)"](GRT, amountToGet, 1, 1)
+            ).to.be.revertedWith("AggregatedOracle: INSUFFICIENT_DATA");
+        });
+
+        it("Should revert if the amount and offset exceed the number of observations but is less than the capacity", async function () {
+            const capacity = 6;
+            const amountToGet = 2;
+
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Sanity check the capacity
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(capacity);
+
+            // Push 2 observation
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+            await expect(
+                oracle["getObservations(address,uint256,uint256,uint256)"](GRT, amountToGet, 1, 1)
+            ).to.be.revertedWith("AggregatedOracle: INSUFFICIENT_DATA");
+        });
+
+        it("Should revert if the increment and amount exceeds the number of observations", async function () {
+            const capacity = 2;
+            const amountToGet = 2;
+            const offset = 0;
+            const increment = 2;
+
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Sanity check the capacity
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(capacity);
+
+            // Push 2 observation
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+            await expect(
+                oracle["getObservations(address,uint256,uint256,uint256)"](GRT, amountToGet, offset, increment)
+            ).to.be.revertedWith("AggregatedOracle: INSUFFICIENT_DATA");
+        });
+
+        it("Should revert if the increment and amount exceeds the number of observations but is less than the capacity", async function () {
+            const capacity = 6;
+            const amountToGet = 2;
+            const offset = 0;
+            const increment = 2;
+
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Sanity check the capacity
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(capacity);
+
+            // Push 2 observation
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+            await expect(
+                oracle["getObservations(address,uint256,uint256,uint256)"](GRT, amountToGet, offset, increment)
+            ).to.be.revertedWith("AggregatedOracle: INSUFFICIENT_DATA");
+        });
+
+        it("Should revert if the increment, amount, and offset exceeds the number of observations", async function () {
+            const capacity = 2;
+            const amountToGet = 2;
+            const offset = 1;
+            const increment = 2;
+
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Sanity check the capacity
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(capacity);
+
+            // Push 3 observation
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+            await expect(
+                oracle["getObservations(address,uint256,uint256,uint256)"](GRT, amountToGet, offset, increment)
+            ).to.be.revertedWith("AggregatedOracle: INSUFFICIENT_DATA");
+        });
+
+        it("Should revert if the increment, amount, and offset exceeds the number of observations but is less than the capacity", async function () {
+            const capacity = 6;
+            const amountToGet = 2;
+            const offset = 1;
+            const increment = 2;
+
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Sanity check the capacity
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(capacity);
+
+            // Push 3 observation
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+
+            await expect(
+                oracle["getObservations(address,uint256,uint256,uint256)"](GRT, amountToGet, offset, increment)
+            ).to.be.revertedWith("AggregatedOracle: INSUFFICIENT_DATA");
+        });
+
+        it("Should return the latest observation many times when increment is 0", async function () {
+            const capacity = 2;
+            const amountToGet = 2;
+            const offset = 0;
+            const increment = 0;
+
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Sanity check the capacity
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(capacity);
+
+            // Push 2 observation
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 2, 2, 2, 2);
+
+            const observations = await oracle["getObservations(address,uint256,uint256,uint256)"](
+                GRT,
+                amountToGet,
+                offset,
+                increment
+            );
+
+            expect(observations.length).to.equal(amountToGet);
+
+            for (let i = 0; i < amountToGet; ++i) {
+                expect(observations[i].price).to.equal(2);
+                expect(observations[i].tokenLiquidity).to.equal(2);
+                expect(observations[i].quoteTokenLiquidity).to.equal(2);
+                expect(observations[i].timestamp).to.equal(2);
+            }
+        });
+
+        async function pushAndCheckObservations(capacity, amountToGet, offset, increment, observationsToPush) {
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Sanity check the capacity
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(capacity);
+
+            for (let i = 0; i < observationsToPush; i++) {
+                await oracle.stubPush(GRT, i, i, i, i);
+            }
+
+            const observations = await oracle["getObservations(address,uint256,uint256,uint256)"](
+                GRT,
+                amountToGet,
+                offset,
+                increment
+            );
+
+            expect(observations.length).to.equal(amountToGet);
+
+            for (let i = 0; i < amountToGet; ++i) {
+                // The latest observation is at index 0 and will have the highest expected values
+                // The following observations will have the expected values decrementing by 1
+                const expected = observationsToPush - i * increment - 1 - offset;
+
+                expect(observations[i].price).to.equal(expected);
+                expect(observations[i].tokenLiquidity).to.equal(expected);
+                expect(observations[i].quoteTokenLiquidity).to.equal(expected);
+                expect(observations[i].timestamp).to.equal(expected);
+            }
+        }
+
+        describe("An increment of 1", function () {
+            describe("An offset of 0", function () {
+                describe("The latest observation is at index 0", function () {
+                    it("Should return the observations in order", async function () {
+                        const capacity = 6;
+                        const amountToGet = 6;
+                        const offset = 0;
+                        const increment = 1;
+
+                        // Push capacity + 1 observations so that the latest observation is at index 0
+                        const observationsToPush = capacity + 1;
+
+                        await pushAndCheckObservations(capacity, amountToGet, offset, increment, observationsToPush);
+                    });
+                });
+
+                describe("The latest observation is at index n-1", function () {
+                    it("Should return the observations in order", async function () {
+                        const capacity = 6;
+                        const amountToGet = 6;
+                        const offset = 0;
+                        const increment = 1;
+
+                        // Push capacity observations so that the latest observation is at index n-1
+                        const observationsToPush = capacity;
+
+                        await pushAndCheckObservations(capacity, amountToGet, offset, increment, observationsToPush);
+                    });
+                });
+            });
+
+            describe("An offset of 1", function () {
+                describe("The latest observation is at index 0", function () {
+                    it("Should return the observations in order", async function () {
+                        const capacity = 6;
+                        const amountToGet = 5;
+                        const offset = 1;
+                        const increment = 1;
+
+                        // Push capacity + 1 observations so that the latest observation is at index 0
+                        const observationsToPush = capacity + 1;
+
+                        await pushAndCheckObservations(capacity, amountToGet, offset, increment, observationsToPush);
+                    });
+                });
+
+                describe("The latest observation is at index n-1", function () {
+                    it("Should return the observations in order", async function () {
+                        const capacity = 6;
+                        const amountToGet = 5;
+                        const offset = 1;
+                        const increment = 1;
+
+                        // Push capacity observations so that the latest observation is at index n-1
+                        const observationsToPush = capacity;
+
+                        await pushAndCheckObservations(capacity, amountToGet, offset, increment, observationsToPush);
+                    });
+                });
+            });
+        });
+
+        describe("An increment of 2", function () {
+            describe("An offset of 0", function () {
+                describe("The latest observation is at index 0", function () {
+                    it("Should return the observations in order", async function () {
+                        const capacity = 6;
+                        const amountToGet = 3;
+                        const offset = 0;
+                        const increment = 2;
+
+                        // Push capacity + 1 observations so that the latest observation is at index 0
+                        const observationsToPush = capacity + 1;
+
+                        await pushAndCheckObservations(capacity, amountToGet, offset, increment, observationsToPush);
+                    });
+                });
+
+                describe("The latest observation is at index n-1", function () {
+                    it("Should return the observations in order", async function () {
+                        const capacity = 6;
+                        const amountToGet = 3;
+                        const offset = 0;
+                        const increment = 2;
+
+                        // Push capacity observations so that the latest observation is at index n-1
+                        const observationsToPush = capacity;
+
+                        await pushAndCheckObservations(capacity, amountToGet, offset, increment, observationsToPush);
+                    });
+                });
+            });
+
+            describe("An offset of 1", function () {
+                describe("The latest observation is at index 0", function () {
+                    it("Should return the observations in order", async function () {
+                        const capacity = 6;
+                        const amountToGet = 2;
+                        const offset = 1;
+                        const increment = 2;
+
+                        // Push capacity + 1 observations so that the latest observation is at index 0
+                        const observationsToPush = capacity + 1;
+
+                        await pushAndCheckObservations(capacity, amountToGet, offset, increment, observationsToPush);
+                    });
+                });
+
+                describe("The latest observation is at index n-1", function () {
+                    it("Should return the observations in order", async function () {
+                        const capacity = 6;
+                        const amountToGet = 2;
+                        const offset = 1;
+                        const increment = 2;
+
+                        // Push capacity observations so that the latest observation is at index n-1
+                        const observationsToPush = capacity;
+
+                        await pushAndCheckObservations(capacity, amountToGet, offset, increment, observationsToPush);
+                    });
+                });
+            });
+        });
+    });
+
+    describe("AggregatedOracle#getObservations(token, amount)", function () {
+        async function pushAndCheckObservations(capacity, amountToGet, offset, increment, observationsToPush) {
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Sanity check the capacity
+            expect(await oracle.getObservationsCapacity(GRT)).to.equal(capacity);
+
+            for (let i = 0; i < observationsToPush; i++) {
+                await oracle.stubPush(GRT, i, i, i, i);
+            }
+
+            const observations = await oracle["getObservations(address,uint256)"](GRT, amountToGet);
+
+            expect(observations.length).to.equal(amountToGet);
+
+            for (let i = 0; i < amountToGet; ++i) {
+                // The latest observation is at index 0 and will have the highest expected values
+                // The following observations will have the expected values decrementing by 1
+                const expected = observationsToPush - i * increment - 1 - offset;
+
+                expect(observations[i].price).to.equal(expected);
+                expect(observations[i].tokenLiquidity).to.equal(expected);
+                expect(observations[i].quoteTokenLiquidity).to.equal(expected);
+                expect(observations[i].timestamp).to.equal(expected);
+            }
+        }
+
+        it("Default offset is 0 and increment is 1", async function () {
+            const capacity = 6;
+            const amountToGet = 6;
+
+            // Push capacity observations so that the latest observation is at index n-1
+            const observationsToPush = capacity;
+
+            await pushAndCheckObservations(capacity, amountToGet, 0, 1, observationsToPush);
+        });
+    });
+
+    describe("AggregatedOracle#getObservationAt", function () {
+        it("Should revert if the buffer is uninitialized", async function () {
+            await expect(oracle.getObservationAt(GRT, 0)).to.be.revertedWith("AggregatedOracle: INVALID_INDEX");
+        });
+
+        it("Should revert if the buffer is initialized but empty", async function () {
+            await oracle.stubInitializeBuffers(GRT);
+
+            await expect(oracle.getObservationAt(GRT, 0)).to.be.revertedWith("AggregatedOracle: INVALID_INDEX");
+        });
+
+        it("Should revert if the index exceeds the number of observations with a full buffer", async function () {
+            const capacity = 6;
+
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Push capacity observations
+            for (let i = 0; i < capacity; ++i) {
+                await oracle.stubPush(GRT, 1, 1, 1, 1);
+            }
+
+            await expect(oracle.getObservationAt(GRT, capacity)).to.be.revertedWith("AggregatedOracle: INVALID_INDEX");
+        });
+
+        it("Should revert if the index exceeds the number of observations but is within the capacity", async function () {
+            const capacity = 6;
+
+            await oracle.setObservationsCapacity(GRT, capacity);
+
+            // Push capacity - 1 observations
+            for (let i = 0; i < capacity - 1; ++i) {
+                await oracle.stubPush(GRT, 1, 1, 1, 1);
+            }
+
+            await expect(oracle.getObservationAt(GRT, capacity - 1)).to.be.revertedWith(
+                "AggregatedOracle: INVALID_INDEX"
+            );
+        });
+
+        it("Should return the latest observation when index = 0", async function () {
+            await oracle.setObservationsCapacity(GRT, 2);
+
+            // Push capacity observations
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 2, 2, 2, 2);
+
+            const observation = await oracle.getObservationAt(GRT, 0);
+
+            expect(observation.price).to.equal(2);
+            expect(observation.tokenLiquidity).to.equal(2);
+            expect(observation.quoteTokenLiquidity).to.equal(2);
+            expect(observation.timestamp).to.equal(2);
+        });
+
+        it("Should return the latest observation when index = 0 and the start was just overwritten", async function () {
+            await oracle.setObservationsCapacity(GRT, 2);
+
+            // Push capacity + 1 observations
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 2, 2, 2, 2);
+            await oracle.stubPush(GRT, 3, 3, 3, 3);
+
+            const observation = await oracle.getObservationAt(GRT, 0);
+
+            expect(observation.price).to.equal(3);
+            expect(observation.tokenLiquidity).to.equal(3);
+            expect(observation.quoteTokenLiquidity).to.equal(3);
+            expect(observation.timestamp).to.equal(3);
+        });
+
+        it("Should return the correct observation when index = 1 and the latest observation is at the start of the buffer", async function () {
+            await oracle.setObservationsCapacity(GRT, 2);
+
+            // Push capacity + 1 observations
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 2, 2, 2, 2);
+            await oracle.stubPush(GRT, 3, 3, 3, 3);
+
+            const observation = await oracle.getObservationAt(GRT, 1);
+
+            expect(observation.price).to.equal(2);
+            expect(observation.tokenLiquidity).to.equal(2);
+            expect(observation.quoteTokenLiquidity).to.equal(2);
+            expect(observation.timestamp).to.equal(2);
+        });
+
+        it("Should return the correct observation when index = 1 and the latest observation is at the end of the buffer", async function () {
+            await oracle.setObservationsCapacity(GRT, 2);
+
+            // Push capacity observations
+            await oracle.stubPush(GRT, 1, 1, 1, 1);
+            await oracle.stubPush(GRT, 2, 2, 2, 2);
+
+            const observation = await oracle.getObservationAt(GRT, 1);
+
+            expect(observation.price).to.equal(1);
+            expect(observation.tokenLiquidity).to.equal(1);
+            expect(observation.quoteTokenLiquidity).to.equal(1);
+            expect(observation.timestamp).to.equal(1);
+        });
+    });
+});

--- a/test/oracles/periodic-accumulation-oracle.js
+++ b/test/oracles/periodic-accumulation-oracle.js
@@ -2526,7 +2526,19 @@ describe("PeriodicAccumulationOracle#push w/ higher granularity", function () {
         // Push OUR_GRANULARITY times
         for (var i = 0; i < OUR_GRANULARITY; ++i) {
             ++totalPushed;
-            await oracle.stubPush(GRT, totalPushed ** 2, totalPushed, totalPushed ** 2, totalPushed ** 2, totalPushed);
+            const pushReceipt = await oracle.stubPush(
+                GRT,
+                totalPushed ** 2,
+                totalPushed,
+                totalPushed ** 2,
+                totalPushed ** 2,
+                totalPushed
+            );
+
+            // Check that the event params match the latest accumulation
+            await expect(pushReceipt)
+                .to.emit(oracle, "AccumulationPushed")
+                .withArgs(GRT, totalPushed ** 2, totalPushed, totalPushed ** 2, totalPushed ** 2, totalPushed);
         }
 
         // Sanity check that we have OUR_GRANULARITY accumulations
@@ -2571,6 +2583,11 @@ describe("PeriodicAccumulationOracle#push w/ higher granularity", function () {
                     observation.quoteTokenLiquidity,
                     observation.timestamp
                 );
+
+            // Check that the event params match the latest accumulation
+            await expect(pushReceipt)
+                .to.emit(oracle, "AccumulationPushed")
+                .withArgs(GRT, totalPushed ** 2, totalPushed, totalPushed ** 2, totalPushed ** 2, totalPushed);
         }
     }
 

--- a/test/oracles/periodic-accumulation-oracle.js
+++ b/test/oracles/periodic-accumulation-oracle.js
@@ -2677,6 +2677,12 @@ function describeHistoricalAccumulationOracleTests(type) {
                     "PeriodicAccumulationOracle: ALREADY_INITIALIZED"
                 );
             });
+
+            it("Emits the correct event", async function () {
+                await expect(oracle.stubInitializeBuffers(GRT))
+                    .to.emit(oracle, "AccumulationCapacityInitialized")
+                    .withArgs(GRT, GRANULARITY);
+            });
         });
 
         const setCapacityFunctionName = "set" + type + "AccumulationsCapacity";

--- a/test/oracles/periodic-accumulation-oracle.js
+++ b/test/oracles/periodic-accumulation-oracle.js
@@ -2628,6 +2628,10 @@ describe("PeriodicAccumulationOracle#push w/ higher granularity", function () {
 });
 
 function describeHistoricalAccumulationOracleTests(type) {
+    const MIN_UPDATE_DELAY = 1;
+    const MAX_UPDATE_DELAY = 60;
+    const TWO_PERCENT_CHANGE = 2000000;
+
     describe("PeriodicAccumulationOracle - IHistorical" + type + "AccumulationOracle implementation", function () {
         var priceAccumulator;
         var liquidityAccumulator;


### PR DESCRIPTION
### Interfaces
- Add IHistoricalOracle interface
- Add IHistoricalPriceAccumulationOracle interface
- Add IHistoricalLiquidityAccumulationOracle interface
- Add IPeriodic#granularity

### Oracles
- Move observation storage out of AbstractOracle
- Make AggregatedOracle implement IHistoricalOracle
- Make PeriodicAccumulationOracle implement IHistoricalPriceAccumulationOracle and IHistoricalLiquidityAccumulationOracle
- Make AggregatedOracle use an extendable ring buffer to store observations, providing up to 65535 historical observations
- Make PeriodicAccumulationOracle use an extendable ring buffer to store accumulations, providing up to 65535 historical accumulations
- Make PeriodicAccumulationOracle emit an AccumulationPushed event when a new accumulation is recorded