### PR TITLE
Release/v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v3.0.0
+### Interfaces
+- Add IHistoricalOracle interface
+- Add IHistoricalPriceAccumulationOracle interface
+- Add IHistoricalLiquidityAccumulationOracle interface
+- Add IPeriodic#granularity
+
+### Oracles
+- Move observation storage out of AbstractOracle
+- Make AggregatedOracle implement IHistoricalOracle
+- Make PeriodicAccumulationOracle implement IHistoricalPriceAccumulationOracle and IHistoricalLiquidityAccumulationOracle
+- Make AggregatedOracle use an extendable ring buffer to store observations, providing up to 65535 historical observations
+- Make PeriodicAccumulationOracle use an extendable ring buffer to store accumulations, providing up to 65535 historical accumulations
+- Make PeriodicAccumulationOracle emit an AccumulationPushed event when a new accumulation is recorded
+
 ## v2.0.0
 ### Oracles
 - Change PeriodicAccumulationOracle freshness metric to use accumulator heartbeats

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrastia-oracle/adrastia-core",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0",
   "main": "index.js",
   "author": "TRILEZ SOFTWARE INC.",
   "license": "MIT",


### PR DESCRIPTION
### Interfaces
- Add IHistoricalOracle interface
- Add IHistoricalPriceAccumulationOracle interface
- Add IHistoricalLiquidityAccumulationOracle interface
- Add IPeriodic#granularity

### Oracles
- Move observation storage out of AbstractOracle
- Make AggregatedOracle implement IHistoricalOracle
- Make PeriodicAccumulationOracle implement IHistoricalPriceAccumulationOracle and IHistoricalLiquidityAccumulationOracle
- Make AggregatedOracle use an extendable ring buffer to store observations, providing up to 65535 historical observations
- Make PeriodicAccumulationOracle use an extendable ring buffer to store accumulations, providing up to 65535 historical accumulations
- Make PeriodicAccumulationOracle emit an AccumulationPushed event when a new accumulation is recorded