### PR TITLE
Release/v4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v4.10.0 (01-JUL-2025)
+### Accumulators
+- Update AdrastiaPriceAccumulator
+  - Use the heartbeat as the maximum observation age when consulting the underlying oracle.
+  - Support instant consultations when `maxAge` is set to 0.
+- Update AdrastiaUtilizationAndErrorAccumulator
+  - Use the heartbeat as the maximum observation age when consulting the underlying oracle.
+  - Support instant consultations when `maxAge` is set to 0.
+- Rename VenusIsolatedSBAccumulator to VenusSBAccumulator
+
+### Oracles
+- Add VenusOracleView: An oracle view that reads from Venus oracles.
+- Add OtfAggregatorOracle: An oracle aggregator that aggregates on-the-fly, rather than serving observations from storage.
+
+### Strategies
+#### Aggregation strategies
+- Add hardcoded timestamp strategies: Rather than always using the current block timestamp, aggregation strategies can now customize the aggregation timestamp.
+  - ThisBlock: Uses the current block timestamp.
+  - EarliestObservation: Uses the timestamp of the earliest (oldest) observation.
+  - LatestObservation: Uses the timestamp of the latest (newest) observation.
+  - FirstObservation: Uses the timestamp of the first observation.
+  - LastObservation: Uses the timestamp of the last observation.
+
 ## v4.9.1
 ### Accumulators
 - Improve SAVPriceAccumulator: Adds conditional underlying oracle heartbeat validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v4.10.0 (01-JUL-2025)
+## v4.10.0 (02-JUL-2025)
 ### Accumulators
 - Update AdrastiaPriceAccumulator
   - Use the heartbeat as the maximum observation age when consulting the underlying oracle.

--- a/contracts/accumulators/LiquidityAccumulator.sol
+++ b/contracts/accumulators/LiquidityAccumulator.sol
@@ -233,7 +233,7 @@ abstract contract LiquidityAccumulator is
     ) public view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
         if (token == quoteTokenAddress()) return (0, 0);
 
-        if (maxAge == 0) return fetchLiquidity(abi.encode(token));
+        if (maxAge == 0) return fetchLiquidity(abi.encode(token), 0);
 
         ObservationLibrary.LiquidityObservation storage observation = observations[token];
 
@@ -387,7 +387,31 @@ abstract contract LiquidityAccumulator is
         return validated;
     }
 
+    /**
+     * @notice Fetches the liquidity for a token.
+     *
+     * @param data The encoded address of the token for which to fetch the liquidity.
+     * @param maxAge The maximum age of the quotation, in seconds. If 0, fetches the real-time liquidity.
+     *
+     * @return tokenLiquidity The liquidity of the token.
+     * @return quoteTokenLiquidity The liquidity of the quote token.
+     */
+    function fetchLiquidity(
+        bytes memory data,
+        uint256 maxAge
+    ) internal view virtual returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity);
+
+    /**
+     * @notice Fetches the liquidity for a token.
+     * @dev This function is a convenience wrapper around `fetchLiquidity(data, _heartbeat())`.
+     *
+     * @param data The encoded address of the token for which to fetch the liquidity.
+     * @return tokenLiquidity The liquidity of the token.
+     * @return quoteTokenLiquidity The liquidity of the quote token.
+     */
     function fetchLiquidity(
         bytes memory data
-    ) internal view virtual returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity);
+    ) internal view virtual returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
+        return fetchLiquidity(data, _heartbeat());
+    }
 }

--- a/contracts/accumulators/LiquidityAccumulator.sol
+++ b/contracts/accumulators/LiquidityAccumulator.sol
@@ -389,6 +389,7 @@ abstract contract LiquidityAccumulator is
 
     /**
      * @notice Fetches the liquidity for a token.
+     * @dev In most cases, maxAge is ignored and this function always fetches the real-time liquidity.
      *
      * @param data The encoded address of the token for which to fetch the liquidity.
      * @param maxAge The maximum age of the quotation, in seconds. If 0, fetches the real-time liquidity.

--- a/contracts/accumulators/PriceAccumulator.sol
+++ b/contracts/accumulators/PriceAccumulator.sol
@@ -210,7 +210,7 @@ abstract contract PriceAccumulator is
     function consultPrice(address token, uint256 maxAge) public view virtual override returns (uint112 price) {
         if (token == quoteTokenAddress()) return uint112(10 ** quoteTokenDecimals());
 
-        if (maxAge == 0) return fetchPrice(abi.encode(token));
+        if (maxAge == 0) return fetchPrice(abi.encode(token), 0);
 
         ObservationLibrary.PriceObservation storage observation = observations[token];
 

--- a/contracts/accumulators/PriceAccumulator.sol
+++ b/contracts/accumulators/PriceAccumulator.sol
@@ -335,5 +335,26 @@ abstract contract PriceAccumulator is
         return validated;
     }
 
-    function fetchPrice(bytes memory data) internal view virtual returns (uint112 price);
+    /**
+     * @notice Fetches the price for a token.
+     * @dev In most cases, maxAge is ignored and this function always fetches the real-time price.
+     *
+     * @param data The encoded address of the token for which to fetch the price.
+     * @param maxAge The maximum age of the quotation, in seconds. If 0, fetches the real-time price.
+     *
+     * @return price The price of the token.
+     */
+    function fetchPrice(bytes memory data, uint256 maxAge) internal view virtual returns (uint112 price);
+
+    /**
+     * @notice Fetches the price for a token.
+     * @dev This function is a convenience wrapper around `fetchPrice(data, _heartbeat())`.
+     *
+     * @param data The encoded address of the token for which to fetch the price.
+     *
+     * @return price The price of the token.
+     */
+    function fetchPrice(bytes memory data) internal view virtual returns (uint112 price) {
+        return fetchPrice(data, _heartbeat());
+    }
 }

--- a/contracts/accumulators/ValueAndErrorAccumulator.sol
+++ b/contracts/accumulators/ValueAndErrorAccumulator.sol
@@ -19,12 +19,15 @@ abstract contract ValueAndErrorAccumulator is LiquidityAccumulator {
         uint256 maxUpdateDelay_
     ) LiquidityAccumulator(averagingStrategy_, quoteToken_, updateThreshold_, minUpdateDelay_, maxUpdateDelay_) {}
 
-    function fetchValue(bytes memory data) internal view virtual returns (uint112 value);
+    function fetchValue(bytes memory data, uint256 maxAge) internal view virtual returns (uint112 value);
 
     function fetchTarget(bytes memory data) internal view virtual returns (uint112 target);
 
-    function fetchLiquidity(bytes memory data) internal view virtual override returns (uint112 value, uint112 err) {
-        value = fetchValue(data);
+    function fetchLiquidity(
+        bytes memory data,
+        uint256 maxAge
+    ) internal view virtual override returns (uint112 value, uint112 err) {
+        value = fetchValue(data, maxAge);
         uint256 target = fetchTarget(data);
 
         if (target >= value) {

--- a/contracts/accumulators/proto/aave/AaveV2RateAccumulator.sol
+++ b/contracts/accumulators/proto/aave/AaveV2RateAccumulator.sol
@@ -51,7 +51,11 @@ contract AaveV2RateAccumulator is PriceAccumulator {
         aaveV2Pool = aaveV2Pool_;
     }
 
-    function fetchPrice(bytes memory data) internal view virtual override returns (uint112 rate) {
+    function fetchPrice(bytes memory data) internal view virtual override returns (uint112) {
+        return fetchPrice(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchPrice(bytes memory data, uint256 /* maxAge */) internal view virtual override returns (uint112 rate) {
         uint256 rateType = abi.decode(data, (uint256));
 
         IAaveV2Pool.ReserveData memory reserveData = IAaveV2Pool(aaveV2Pool).getReserveData(quoteTokenAddress());

--- a/contracts/accumulators/proto/aave/AaveV3RateAccumulator.sol
+++ b/contracts/accumulators/proto/aave/AaveV3RateAccumulator.sol
@@ -60,7 +60,11 @@ contract AaveV3RateAccumulator is PriceAccumulator {
         aaveV3Pool = aaveV3Pool_;
     }
 
-    function fetchPrice(bytes memory data) internal view virtual override returns (uint112 rate) {
+    function fetchPrice(bytes memory data) internal view virtual override returns (uint112) {
+        return fetchPrice(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchPrice(bytes memory data, uint256 /* maxAge */) internal view virtual override returns (uint112 rate) {
         uint256 rateType = abi.decode(data, (uint256));
 
         IAaveV3Pool.ReserveData memory reserveData = IAaveV3Pool(aaveV3Pool).getReserveData(quoteTokenAddress());

--- a/contracts/accumulators/proto/aave/AaveV3SBAccumulator.sol
+++ b/contracts/accumulators/proto/aave/AaveV3SBAccumulator.sol
@@ -75,6 +75,13 @@ contract AaveV3SBAccumulator is LiquidityAccumulator {
     function fetchLiquidity(
         bytes memory data
     ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
+        return fetchLiquidity(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchLiquidity(
+        bytes memory data,
+        uint256 /* maxAge */ // maxAge is not used in this implementation
+    ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
         address token = abi.decode(data, (address));
         IAaveV3Pool.ReserveData memory reserveData = IAaveV3Pool(aaveV3Pool).getReserveData(token);
 

--- a/contracts/accumulators/proto/adrastia/AdrastiaPriceAccumulator.sol
+++ b/contracts/accumulators/proto/adrastia/AdrastiaPriceAccumulator.sol
@@ -92,10 +92,10 @@ contract AdrastiaPriceAccumulator is PriceAccumulator {
      * @return price The price of the specified token in terms of the quote token, scaled by the quote token decimal
      *   places.
      */
-    function fetchPrice(bytes memory data) internal view virtual override returns (uint112 price) {
+    function fetchPrice(bytes memory data, uint256 maxAge) internal view virtual override returns (uint112 price) {
         address token = abi.decode(data, (address));
 
-        return IPriceOracle(adrastiaOracle).consultPrice(token, _heartbeat());
+        return IPriceOracle(adrastiaOracle).consultPrice(token, maxAge);
     }
 
     function validateObservation(bytes memory updateData, uint112 price) internal virtual override returns (bool) {

--- a/contracts/accumulators/proto/adrastia/AdrastiaUtilizationAndErrorAccumulator.sol
+++ b/contracts/accumulators/proto/adrastia/AdrastiaUtilizationAndErrorAccumulator.sol
@@ -43,10 +43,13 @@ contract AdrastiaUtilizationAndErrorAccumulator is ValueAndErrorAccumulator {
         return _liquidityDecimals;
     }
 
-    function fetchValue(bytes memory data) internal view virtual override returns (uint112) {
+    function fetchValue(bytes memory data, uint256 maxAge) internal view virtual override returns (uint112) {
         address token = abi.decode(data, (address));
 
-        (uint256 totalBorrow, uint256 totalSupply) = ILiquidityOracle(_supplyAndBorrowOracle).consultLiquidity(token);
+        (uint256 totalBorrow, uint256 totalSupply) = ILiquidityOracle(_supplyAndBorrowOracle).consultLiquidity(
+            token,
+            maxAge
+        );
 
         if (totalSupply == 0) {
             if (_considerEmptyAs100Percent) {

--- a/contracts/accumulators/proto/algebra/AlgebraLiquidityAccumulator.sol
+++ b/contracts/accumulators/proto/algebra/AlgebraLiquidityAccumulator.sol
@@ -90,6 +90,13 @@ contract AlgebraLiquidityAccumulator is LiquidityAccumulator {
     function fetchLiquidity(
         bytes memory data
     ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
+        return fetchLiquidity(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchLiquidity(
+        bytes memory data,
+        uint256 /* maxAge */ // maxAge is not used in this implementation
+    ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
         address token = abi.decode(data, (address));
         address _quoteToken = quoteToken;
         if (token == _quoteToken || token == address(0)) {

--- a/contracts/accumulators/proto/algebra/AlgebraPriceAccumulator.sol
+++ b/contracts/accumulators/proto/algebra/AlgebraPriceAccumulator.sol
@@ -110,6 +110,10 @@ contract AlgebraPriceAccumulator is PriceAccumulator {
     }
 
     function fetchPrice(bytes memory data) internal view virtual override returns (uint112) {
+        return fetchPrice(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchPrice(bytes memory data, uint256 /* maxAge */) internal view virtual override returns (uint112) {
         address token = abi.decode(data, (address));
         if (token == quoteToken || token == address(0)) {
             // Invalid token

--- a/contracts/accumulators/proto/balancer/BalancerV2LiquidityAccumulator.sol
+++ b/contracts/accumulators/proto/balancer/BalancerV2LiquidityAccumulator.sol
@@ -184,6 +184,13 @@ contract BalancerV2LiquidityAccumulator is LiquidityAccumulator {
     function fetchLiquidity(
         bytes memory data
     ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
+        return fetchLiquidity(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchLiquidity(
+        bytes memory data,
+        uint256 /* maxAge */ // maxAge is not used in this implementation
+    ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
         // Ensure that the pool is not in recovery mode
         if (isPaused(poolAddress)) {
             revert PoolIsPaused(poolAddress);

--- a/contracts/accumulators/proto/balancer/BalancerV2StablePriceAccumulator.sol
+++ b/contracts/accumulators/proto/balancer/BalancerV2StablePriceAccumulator.sol
@@ -206,6 +206,10 @@ contract BalancerV2StablePriceAccumulator is PriceAccumulator {
         return (false, 0, false, 0);
     }
 
+    function fetchPrice(bytes memory data) internal view virtual override returns (uint112) {
+        return fetchPrice(data, 0 /* not used - save on gas */);
+    }
+
     /**
      * @notice Calculates the price of a token.
      * @dev When the price equals 0, a price of 1 is actually returned.
@@ -213,7 +217,10 @@ contract BalancerV2StablePriceAccumulator is PriceAccumulator {
      * @return price The price of the specified token in terms of the quote token, scaled by the quote token decimal
      *   places.
      */
-    function fetchPrice(bytes memory data) internal view virtual override returns (uint112 price) {
+    function fetchPrice(
+        bytes memory data,
+        uint256 /* maxAge */
+    ) internal view virtual override returns (uint112 price) {
         // Ensure that the pool is not in recovery mode
         if (isPaused(poolAddress)) {
             revert PoolIsPaused(poolAddress);

--- a/contracts/accumulators/proto/balancer/BalancerV2WeightedPriceAccumulator.sol
+++ b/contracts/accumulators/proto/balancer/BalancerV2WeightedPriceAccumulator.sol
@@ -123,6 +123,10 @@ contract BalancerV2WeightedPriceAccumulator is PriceAccumulator {
         return type(uint256).max;
     }
 
+    function fetchPrice(bytes memory data) internal view virtual override returns (uint112) {
+        return fetchPrice(data, 0 /* not used - save on gas */);
+    }
+
     /**
      * @notice Calculates the price of a token.
      * @dev When the price equals 0, a price of 1 is actually returned.
@@ -130,7 +134,10 @@ contract BalancerV2WeightedPriceAccumulator is PriceAccumulator {
      * @return price The price of the specified token in terms of the quote token, scaled by the quote token decimal
      *   places.
      */
-    function fetchPrice(bytes memory data) internal view virtual override returns (uint112 price) {
+    function fetchPrice(
+        bytes memory data,
+        uint256 /* maxAge */
+    ) internal view virtual override returns (uint112 price) {
         // Ensure that the pool is not in recovery mode
         if (isPaused(poolAddress)) {
             revert PoolIsPaused(poolAddress);

--- a/contracts/accumulators/proto/compound/CometRateAccumulator.sol
+++ b/contracts/accumulators/proto/compound/CometRateAccumulator.sol
@@ -40,7 +40,11 @@ contract CometRateAccumulator is PriceAccumulator {
         comet = comet_;
     }
 
-    function fetchPrice(bytes memory data) internal view virtual override returns (uint112 rate) {
+    function fetchPrice(bytes memory data) internal view virtual override returns (uint112) {
+        return fetchPrice(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchPrice(bytes memory data, uint256 /* maxAge */) internal view virtual override returns (uint112 rate) {
         uint256 rateType = abi.decode(data, (uint256));
 
         uint256 utilization = IComet(comet).getUtilization();

--- a/contracts/accumulators/proto/compound/CometSBAccumulator.sol
+++ b/contracts/accumulators/proto/compound/CometSBAccumulator.sol
@@ -58,6 +58,13 @@ contract CometSBAccumulator is LiquidityAccumulator {
     function fetchLiquidity(
         bytes memory data
     ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
+        return fetchLiquidity(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchLiquidity(
+        bytes memory data,
+        uint256 /* maxAge */ // maxAge is not used in this implementation
+    ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
         address token = abi.decode(data, (address));
         if (token == baseToken) {
             // Base token can be both supplied and borrowed

--- a/contracts/accumulators/proto/compound/CompoundV2RateAccumulator.sol
+++ b/contracts/accumulators/proto/compound/CompoundV2RateAccumulator.sol
@@ -36,7 +36,11 @@ contract CompoundV2RateAccumulator is PriceAccumulator {
         cToken = cToken_;
     }
 
-    function fetchPrice(bytes memory data) internal view virtual override returns (uint112 rate) {
+    function fetchPrice(bytes memory data) internal view virtual override returns (uint112) {
+        return fetchPrice(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchPrice(bytes memory data, uint256 /* maxAge */) internal view virtual override returns (uint112 rate) {
         uint256 rateType = abi.decode(data, (uint256));
 
         if (rateType == 16) {

--- a/contracts/accumulators/proto/compound/CompoundV2SBAccumulator.sol
+++ b/contracts/accumulators/proto/compound/CompoundV2SBAccumulator.sol
@@ -199,6 +199,13 @@ contract CompoundV2SBAccumulator is LiquidityAccumulator {
     function fetchLiquidity(
         bytes memory data
     ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
+        return fetchLiquidity(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchLiquidity(
+        bytes memory data,
+        uint256 /* maxAge */ // maxAge is not used in this implementation
+    ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
         address token = abi.decode(data, (address));
         (ICToken cToken, uint8 decimals) = tokenInfo(token);
         if (address(cToken) == address(0)) {

--- a/contracts/accumulators/proto/curve/CurveLiquidityAccumulator.sol
+++ b/contracts/accumulators/proto/curve/CurveLiquidityAccumulator.sol
@@ -77,6 +77,13 @@ contract CurveLiquidityAccumulator is LiquidityAccumulator {
     function fetchLiquidity(
         bytes memory data
     ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
+        return fetchLiquidity(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchLiquidity(
+        bytes memory data,
+        uint256 /* maxAge */ // maxAge is not used in this implementation
+    ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
         address token = abi.decode(data, (address));
 
         ICurvePool pool = ICurvePool(curvePool);

--- a/contracts/accumulators/proto/curve/CurvePriceAccumulator.sol
+++ b/contracts/accumulators/proto/curve/CurvePriceAccumulator.sol
@@ -65,6 +65,10 @@ contract CurvePriceAccumulator is PriceAccumulator {
         return super.canUpdate(data);
     }
 
+    function fetchPrice(bytes memory data) internal view virtual override returns (uint112) {
+        return fetchPrice(data, 0 /* not used - save on gas */);
+    }
+
     /**
      * @notice Calculates the price of a token.
      * @dev When the price equals 0, a price of 1 is actually returned.
@@ -72,7 +76,10 @@ contract CurvePriceAccumulator is PriceAccumulator {
      * @return price The price of the specified token in terms of the quote token, scaled by the quote token decimal
      *   places.
      */
-    function fetchPrice(bytes memory data) internal view virtual override returns (uint112 price) {
+    function fetchPrice(
+        bytes memory data,
+        uint256 /* maxAge */
+    ) internal view virtual override returns (uint112 price) {
         address token = abi.decode(data, (address));
 
         TokenConfig memory config = tokenIndices[token];

--- a/contracts/accumulators/proto/erc4626/SAVPriceAccumulator.sol
+++ b/contracts/accumulators/proto/erc4626/SAVPriceAccumulator.sol
@@ -84,6 +84,10 @@ contract SAVPriceAccumulator is PriceAccumulator {
     }
 
     function fetchPrice(bytes memory data) internal view virtual override returns (uint112) {
+        return fetchPrice(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchPrice(bytes memory data, uint256 /* maxAge */) internal view virtual override returns (uint112) {
         IERC4626 vault = IERC4626(abi.decode(data, (address)));
         uint256 vaultSupply = vault.totalSupply();
 

--- a/contracts/accumulators/proto/offchain/OffchainLiquidityAccumulator.sol
+++ b/contracts/accumulators/proto/offchain/OffchainLiquidityAccumulator.sol
@@ -76,7 +76,16 @@ contract OffchainLiquidityAccumulator is LiquidityAccumulator {
         return _liquidityDecimals;
     }
 
-    function fetchLiquidity(bytes memory data) internal view virtual override returns (uint112, uint112) {
+    function fetchLiquidity(
+        bytes memory data
+    ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
+        return fetchLiquidity(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchLiquidity(
+        bytes memory data,
+        uint256 /* maxAge */
+    ) internal view virtual override returns (uint112, uint112) {
         (, uint112 tokenLiquidity, uint112 quoteTokenLiquidity) = abi.decode(data, (address, uint112, uint112));
 
         return (tokenLiquidity, quoteTokenLiquidity);

--- a/contracts/accumulators/proto/offchain/OffchainPriceAccumulator.sol
+++ b/contracts/accumulators/proto/offchain/OffchainPriceAccumulator.sol
@@ -47,6 +47,10 @@ contract OffchainPriceAccumulator is PriceAccumulator {
     }
 
     function fetchPrice(bytes memory data) internal view virtual override returns (uint112) {
+        return fetchPrice(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchPrice(bytes memory data, uint256 /* maxAge */) internal view virtual override returns (uint112) {
         (, uint112 price) = abi.decode(data, (address, uint112));
 
         return price;

--- a/contracts/accumulators/proto/static/StaticLiquidityAccumulator.sol
+++ b/contracts/accumulators/proto/static/StaticLiquidityAccumulator.sol
@@ -94,7 +94,7 @@ contract StaticLiquidityAccumulator is LiquidityAccumulator {
         return (staticTokenLiquidity, staticQuoteTokenLiquidity);
     }
 
-    function fetchLiquidity(bytes memory) internal view virtual override returns (uint112, uint112) {
+    function fetchLiquidity(bytes memory, uint256) internal view virtual override returns (uint112, uint112) {
         return (staticTokenLiquidity, staticQuoteTokenLiquidity);
     }
 }

--- a/contracts/accumulators/proto/static/StaticPriceAccumulator.sol
+++ b/contracts/accumulators/proto/static/StaticPriceAccumulator.sol
@@ -69,7 +69,7 @@ contract StaticPriceAccumulator is PriceAccumulator {
         return staticPrice;
     }
 
-    function fetchPrice(bytes memory) internal view virtual override returns (uint112) {
+    function fetchPrice(bytes memory, uint256) internal view virtual override returns (uint112) {
         return staticPrice;
     }
 }

--- a/contracts/accumulators/proto/truefi/AlocUtilizationAndErrorAccumulator.sol
+++ b/contracts/accumulators/proto/truefi/AlocUtilizationAndErrorAccumulator.sol
@@ -48,7 +48,7 @@ contract AlocUtilizationAndErrorAccumulator is ValueAndErrorAccumulator {
         return _liquidityDecimals;
     }
 
-    function fetchValue(bytes memory data) internal view virtual override returns (uint112) {
+    function fetchValue(bytes memory data, uint256 /* maxAge */) internal view virtual override returns (uint112) {
         address alocAddress = abi.decode(data, (address));
 
         uint256 utilization = IAloc(alocAddress).utilization();

--- a/contracts/accumulators/proto/uniswap/UniswapV2LiquidityAccumulator.sol
+++ b/contracts/accumulators/proto/uniswap/UniswapV2LiquidityAccumulator.sol
@@ -67,6 +67,13 @@ contract UniswapV2LiquidityAccumulator is LiquidityAccumulator {
     function fetchLiquidity(
         bytes memory data
     ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
+        return fetchLiquidity(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchLiquidity(
+        bytes memory data,
+        uint256 /* maxAge */ // maxAge is not used in this implementation
+    ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
         address token = abi.decode(data, (address));
 
         address pairAddress = pairFor(uniswapFactory, initCodeHash, token, quoteToken);

--- a/contracts/accumulators/proto/uniswap/UniswapV2PriceAccumulator.sol
+++ b/contracts/accumulators/proto/uniswap/UniswapV2PriceAccumulator.sol
@@ -54,6 +54,10 @@ contract UniswapV2PriceAccumulator is PriceAccumulator {
         return super.canUpdate(data);
     }
 
+    function fetchPrice(bytes memory data) internal view virtual override returns (uint112) {
+        return fetchPrice(data, 0 /* not used - save on gas */);
+    }
+
     /**
      * @notice Calculates the price of a token.
      * @dev When the price equals 0, a price of 1 is actually returned.
@@ -61,7 +65,10 @@ contract UniswapV2PriceAccumulator is PriceAccumulator {
      * @return price The price of the specified token in terms of the quote token, scaled by the quote token decimal
      *   places.
      */
-    function fetchPrice(bytes memory data) internal view virtual override returns (uint112 price) {
+    function fetchPrice(
+        bytes memory data,
+        uint256 /* maxAge */
+    ) internal view virtual override returns (uint112 price) {
         address token = abi.decode(data, (address));
 
         address pairAddress = pairFor(uniswapFactory, initCodeHash, token, quoteToken);

--- a/contracts/accumulators/proto/uniswap/UniswapV3LiquidityAccumulator.sol
+++ b/contracts/accumulators/proto/uniswap/UniswapV3LiquidityAccumulator.sol
@@ -110,6 +110,13 @@ contract UniswapV3LiquidityAccumulator is LiquidityAccumulator {
     function fetchLiquidity(
         bytes memory data
     ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
+        return fetchLiquidity(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchLiquidity(
+        bytes memory data,
+        uint256 /* maxAge */ // maxAge is not used in this implementation
+    ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
         address token = abi.decode(data, (address));
 
         require(token != address(0), "UniswapV3LiquidityAccumulator: INVALID_TOKEN");

--- a/contracts/accumulators/proto/uniswap/UniswapV3PriceAccumulator.sol
+++ b/contracts/accumulators/proto/uniswap/UniswapV3PriceAccumulator.sol
@@ -137,6 +137,10 @@ contract UniswapV3PriceAccumulator is PriceAccumulator {
     }
 
     function fetchPrice(bytes memory data) internal view virtual override returns (uint112) {
+        return fetchPrice(data, 0 /* not used - save on gas */);
+    }
+
+    function fetchPrice(bytes memory data, uint256 /* maxAge */) internal view virtual override returns (uint112) {
         address token = abi.decode(data, (address));
 
         require(token != quoteToken, "UniswapV3PriceAccumulator: IDENTICAL_ADDRESSES");

--- a/contracts/accumulators/proto/venus/VenusSBAccumulator.sol
+++ b/contracts/accumulators/proto/venus/VenusSBAccumulator.sol
@@ -7,7 +7,13 @@ interface VToken {
     function badDebt() external view returns (uint256);
 }
 
-contract VenusIsolatedSBAccumulator is CompoundV2SBAccumulator {
+/**
+ * @title VenusSBAccumulator - Venus Supply & Borrow Accumulator
+ * @author Tyler Loewen, TRILEZ SOFTWARE INC. dba. Adrastia
+ * @notice A Supply & Borrow Accumulator for the Venus protocol, extending the CompoundV2SBAccumulator.
+ * @dev This contract is made for vTokens that implement the `badDebt` function.
+ */
+contract VenusSBAccumulator is CompoundV2SBAccumulator {
     constructor(
         IAveragingStrategy averagingStrategy_,
         address comptroller_,

--- a/contracts/oracles/HistoricalOracle.sol
+++ b/contracts/oracles/HistoricalOracle.sol
@@ -109,12 +109,12 @@ abstract contract HistoricalOracle is IHistoricalOracle {
         uint256 amount,
         uint256 offset,
         uint256 increment
-    ) external view virtual returns (ObservationLibrary.Observation[] memory) {
+    ) external view virtual override returns (ObservationLibrary.Observation[] memory) {
         return getObservationsInternal(token, amount, offset, increment);
     }
 
     /// @inheritdoc IHistoricalOracle
-    function getObservationsCount(address token) external view override returns (uint256) {
+    function getObservationsCount(address token) external view virtual override returns (uint256) {
         return observationBufferMetadata[token].size;
     }
 

--- a/contracts/oracles/OtfAggregatorOracle.sol
+++ b/contracts/oracles/OtfAggregatorOracle.sol
@@ -49,12 +49,16 @@ contract OtfAggregatorOracle is AbstractAggregatorOracle {
 
     function getLatestObservation(
         address token
-    ) public view virtual override returns (ObservationLibrary.Observation memory observation) {
-        uint256 validResponses;
-        (observation, validResponses) = aggregateUnderlying(token, _maximumResponseAge(token));
+    ) public view virtual override returns (ObservationLibrary.Observation memory) {
+        (ObservationLibrary.Observation memory observation, uint256 validResponses) = aggregateUnderlying(
+            token,
+            _maximumResponseAge(token)
+        );
 
         uint256 minResponses = _minimumResponses(token);
         require(validResponses >= minResponses, "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS");
+
+        return observation;
     }
 
     /// @notice Not supported.

--- a/contracts/oracles/OtfAggregatorOracle.sol
+++ b/contracts/oracles/OtfAggregatorOracle.sol
@@ -59,7 +59,12 @@ contract OtfAggregatorOracle is AbstractAggregatorOracle {
 
     /// @notice Not supported.
     function update(bytes memory) public virtual override returns (bool) {
-        revert("Not supported");
+        return false;
+    }
+
+    function canUpdate(bytes memory) public pure virtual override returns (bool) {
+        // This oracle does not support updates, so it cannot be updated.
+        return false;
     }
 
     /// @notice Always returns false, as this oracle does not store observations and does not need to be updated.
@@ -112,8 +117,8 @@ contract OtfAggregatorOracle is AbstractAggregatorOracle {
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override(AbstractAggregatorOracle) returns (bool) {
-        if (interfaceId == type(IUpdateable).interfaceId || interfaceId == type(IHistoricalOracle).interfaceId) {
-            // This oracle does not support IUpdateable or IHistoricalOracle (unlike the parent contracts)
+        if (interfaceId == type(IHistoricalOracle).interfaceId) {
+            // This oracle does not support IHistoricalOracle (unlike the parent contracts)
             return false;
         }
 

--- a/contracts/oracles/OtfAggregatorOracle.sol
+++ b/contracts/oracles/OtfAggregatorOracle.sol
@@ -134,16 +134,4 @@ contract OtfAggregatorOracle is AbstractAggregatorOracle {
     function _maximumResponseAge(address) internal view virtual override returns (uint256) {
         return _minimumFreshness;
     }
-
-    /// @inheritdoc AbstractAggregatorOracle
-    /// @dev This oracle won't update its underlying oracles.
-    function canUpdateUnderlyingOracles(bytes memory) internal view virtual override returns (bool) {
-        return false;
-    }
-
-    /// @inheritdoc AbstractAggregatorOracle
-    /// @dev This oracle won't update its underlying oracles.
-    function updateUnderlyingOracles(bytes memory) internal virtual override returns (bool) {
-        return false;
-    }
 }

--- a/contracts/oracles/OtfAggregatorOracle.sol
+++ b/contracts/oracles/OtfAggregatorOracle.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.13;
+
+import "./AbstractAggregatorOracle.sol";
+
+/**
+ * @title On-The-Fly Aggregator Oracle (OtfAggregatorOracle)
+ * @notice An aggregator oracle that performs aggregation on-the-fly without storing observations.
+ */
+contract OtfAggregatorOracle is AbstractAggregatorOracle {
+    /**
+     * @notice The minimum freshness of the aggregated observations. The age of the underlying oracles' responses must
+     * be less than or equal to this value for the data to be considered valid.
+     * @dev This value is passed to the underlying oracles when performing consultations.
+     */
+    uint256 internal immutable _minimumFreshness;
+
+    /**
+     * @notice The minimum number of valid responses required for the aggregation to be considered valid.
+     */
+    uint256 internal immutable _minResponses;
+
+    constructor(
+        AbstractAggregatorOracleParams memory params,
+        uint256 minimumFreshness_,
+        uint256 minResponses_
+    ) AbstractAggregatorOracle(params) {
+        _validateMinimumFreshness(minimumFreshness_);
+        // Note: We choose not to validate the min responses against the provided oracles, as the existance of
+        // token-specific oracles can make expectations unclear.
+        _validateMinimumResponses(minResponses_);
+        _minimumFreshness = minimumFreshness_;
+        _minResponses = minResponses_;
+    }
+
+    function getLatestObservation(
+        address token
+    ) public view virtual override returns (ObservationLibrary.Observation memory observation) {
+        uint256 validResponses;
+        (observation, validResponses) = aggregateUnderlying(token, _maximumResponseAge(token));
+
+        uint256 minResponses = _minimumResponses(token);
+        require(validResponses >= minResponses, "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS");
+    }
+
+    /// @notice Not supported.
+    function update(bytes memory) public virtual override returns (bool) {
+        revert("Not supported");
+    }
+
+    /// @notice Always returns false, as this oracle does not store observations and does not need to be updated.
+    function needsUpdate(bytes memory) public pure virtual override returns (bool) {
+        return false;
+    }
+
+    /// @notice Not supported.
+    function getObservationAt(
+        address,
+        uint256
+    ) external pure virtual override returns (ObservationLibrary.Observation memory) {
+        revert("Not supported");
+    }
+
+    /// @notice Not supported.
+    function getObservations(
+        address,
+        uint256
+    ) external pure virtual override returns (ObservationLibrary.Observation[] memory) {
+        revert("Not supported");
+    }
+
+    /// @notice Not supported.
+    function getObservations(
+        address,
+        uint256,
+        uint256,
+        uint256
+    ) external pure virtual override returns (ObservationLibrary.Observation[] memory) {
+        revert("Not supported");
+    }
+
+    /// @notice Not supported.
+    function getObservationsCount(address) external pure override returns (uint256) {
+        revert("Not supported");
+    }
+
+    /// @notice Not supported.
+    function getObservationsCapacity(address) external pure virtual override returns (uint256) {
+        revert("Not supported");
+    }
+
+    /// @notice Not supported.
+    function setObservationsCapacity(address, uint256) external virtual override {
+        revert("Not supported");
+    }
+
+    /// @inheritdoc IERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(AbstractAggregatorOracle) returns (bool) {
+        return AbstractAggregatorOracle.supportsInterface(interfaceId);
+    }
+
+    function _validateMinimumFreshness(uint256 minimumFreshness_) internal pure virtual {
+        require(minimumFreshness_ > 0, "OtfAggregatorOracle: INVALID_MINIMUM_FRESHNESS");
+    }
+
+    function _validateMinimumResponses(uint256 minResponses_) internal pure virtual {
+        require(minResponses_ > 0, "OtfAggregatorOracle: INVALID_MIN_RESPONSES");
+    }
+
+    function _minimumResponses(address) internal view virtual override returns (uint256) {
+        return 1;
+    }
+
+    function _maximumResponseAge(address) internal view virtual override returns (uint256) {
+        return _minimumFreshness;
+    }
+
+    /// @inheritdoc AbstractAggregatorOracle
+    /// @dev This oracle won't update its underlying oracles.
+    function canUpdateUnderlyingOracles(bytes memory) internal view virtual override returns (bool) {
+        return false;
+    }
+
+    /// @inheritdoc AbstractAggregatorOracle
+    /// @dev This oracle won't update its underlying oracles.
+    function updateUnderlyingOracles(bytes memory) internal virtual override returns (bool) {
+        return false;
+    }
+}

--- a/contracts/oracles/OtfAggregatorOracle.sol
+++ b/contracts/oracles/OtfAggregatorOracle.sol
@@ -20,6 +20,20 @@ contract OtfAggregatorOracle is AbstractAggregatorOracle {
      */
     uint256 internal immutable _minResponses;
 
+    /**
+     * @notice An error thrown when the minimum freshness is invalid.
+     * @param providedMinFreshness The provided minimum freshness that caused the error.
+     * @param minFreshness The minimum freshness that is required.
+     */
+    error InvalidMinimumFreshness(uint256 providedMinFreshness, uint256 minFreshness);
+
+    /**
+     * @notice An error thrown when the minimum number of responses is invalid.
+     * @param providedMinResponses The provided minimum number of responses that caused the error.
+     * @param minResponses The minimum number of responses that is required.
+     */
+    error InvalidMinimumResponses(uint256 providedMinResponses, uint256 minResponses);
+
     constructor(
         AbstractAggregatorOracleParams memory params,
         uint256 minimumFreshness_,
@@ -102,11 +116,15 @@ contract OtfAggregatorOracle is AbstractAggregatorOracle {
     }
 
     function _validateMinimumFreshness(uint256 minimumFreshness_) internal pure virtual {
-        require(minimumFreshness_ > 0, "OtfAggregatorOracle: INVALID_MINIMUM_FRESHNESS");
+        if (minimumFreshness_ == 0) {
+            revert InvalidMinimumFreshness(minimumFreshness_, 1);
+        }
     }
 
     function _validateMinimumResponses(uint256 minResponses_) internal pure virtual {
-        require(minResponses_ > 0, "OtfAggregatorOracle: INVALID_MIN_RESPONSES");
+        if (minResponses_ == 0) {
+            revert InvalidMinimumResponses(minResponses_, 1);
+        }
     }
 
     function _minimumResponses(address) internal view virtual override returns (uint256) {

--- a/contracts/oracles/OtfAggregatorOracle.sol
+++ b/contracts/oracles/OtfAggregatorOracle.sol
@@ -112,6 +112,11 @@ contract OtfAggregatorOracle is AbstractAggregatorOracle {
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override(AbstractAggregatorOracle) returns (bool) {
+        if (interfaceId == type(IUpdateable).interfaceId || interfaceId == type(IHistoricalOracle).interfaceId) {
+            // This oracle does not support IUpdateable or IHistoricalOracle (unlike the parent contracts)
+            return false;
+        }
+
         return AbstractAggregatorOracle.supportsInterface(interfaceId);
     }
 

--- a/contracts/oracles/OtfAggregatorOracle.sol
+++ b/contracts/oracles/OtfAggregatorOracle.sol
@@ -110,7 +110,7 @@ contract OtfAggregatorOracle is AbstractAggregatorOracle {
     }
 
     function _minimumResponses(address) internal view virtual override returns (uint256) {
-        return 1;
+        return _minResponses;
     }
 
     function _maximumResponseAge(address) internal view virtual override returns (uint256) {

--- a/contracts/oracles/views/VenusOracleView.sol
+++ b/contracts/oracles/views/VenusOracleView.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.13;
+
+import "../AbstractOracle.sol";
+import "../../utils/ExplicitQuotationMetadata.sol";
+
+interface OracleInterface {
+    function getPrice(address asset) external view returns (uint256);
+}
+
+/**
+ * @title VenusOracleView
+ * @author Tyler Loewen, TRILEZ SOFTWARE INC. dba. Adrastia
+ * @notice A view oracle that retrieves prices from the Venus oracle contract and normalizes them to a specific number
+ * of decimals.
+ */
+contract VenusOracleView is AbstractOracle, ExplicitQuotationMetadata {
+    /**
+     * @notice The address of the Venus oracle contract.
+     */
+    address internal immutable venusOracle;
+
+    /**
+     * @notice An error thrown when the timestamp is invalid.
+     * @dev The timestamp is expected to be a valid Unix timestamp and should not exceed type(uint32).max.
+     * @param timestamp The invalid timestamp.
+     */
+    error InvalidTimestamp(uint256 timestamp);
+
+    /**
+     * @notice An error thrown when the price exceeds the maximum allowed value.
+     * @dev The price is expected to be less than or equal to type(uint112).max.
+     */
+    error AnswerTooLarge(uint256 answer);
+
+    /**
+     * @notice An error thrown when the provided quote token decimals are not 18.
+     * @dev The provided quote token is expected to have 18 decimals.
+     * @param decimals The number of decimals of the quote token.
+     */
+    error InvalidQuoteTokenDecimals(uint8 decimals);
+
+    /**
+     * @notice Constructs a new VenusOracleView instance.
+     *
+     * @param venusOracle_ The address of the Venus oracle contract. This contract is expected to provide a
+     * `getPrice(address asset)` function.
+     * @param quoteTokenName_ The name of the quote token. Informational only.
+     * @param quoteTokenAddress_ The address of the quote token. Informational only.
+     * @param quoteTokenSymbol_ The symbol of the quote token. Informational only.
+     * @param quoteTokenDecimals_ The number of decimals used when returning price quotations.
+     */
+    constructor(
+        address venusOracle_,
+        string memory quoteTokenName_,
+        address quoteTokenAddress_,
+        string memory quoteTokenSymbol_,
+        uint8 quoteTokenDecimals_
+    )
+        AbstractOracle(quoteTokenAddress_)
+        ExplicitQuotationMetadata(quoteTokenName_, quoteTokenAddress_, quoteTokenSymbol_, quoteTokenDecimals_)
+    {
+        venusOracle = venusOracle_;
+    }
+
+    /// @inheritdoc IQuoteToken
+    function quoteTokenName()
+        public
+        view
+        virtual
+        override(ExplicitQuotationMetadata, SimpleQuotationMetadata, IQuoteToken)
+        returns (string memory)
+    {
+        return _quoteTokenName;
+    }
+
+    /// @inheritdoc IQuoteToken
+    function quoteTokenAddress()
+        public
+        view
+        virtual
+        override(ExplicitQuotationMetadata, SimpleQuotationMetadata, IQuoteToken)
+        returns (address)
+    {
+        return _quoteTokenAddress;
+    }
+
+    /// @inheritdoc IQuoteToken
+    function quoteTokenSymbol()
+        public
+        view
+        virtual
+        override(ExplicitQuotationMetadata, SimpleQuotationMetadata, IQuoteToken)
+        returns (string memory)
+    {
+        return _quoteTokenSymbol;
+    }
+
+    /// @inheritdoc IQuoteToken
+    function quoteTokenDecimals()
+        public
+        view
+        virtual
+        override(ExplicitQuotationMetadata, SimpleQuotationMetadata, IQuoteToken)
+        returns (uint8)
+    {
+        return _quoteTokenDecimals;
+    }
+
+    /// @inheritdoc IOracle
+    function liquidityDecimals() public view virtual override returns (uint8) {
+        return 0; // Liquidity is not supported
+    }
+
+    /**
+     * @notice Updates the oracle data.
+     * @dev This oracle doesn't support updates.
+     * @return False as this oracle doesn't support updates.
+     */
+    function update(bytes memory) public virtual override returns (bool) {
+        return false;
+    }
+
+    /**
+     * @notice Checks if the oracle needs an update.
+     * @dev This oracle doesn't support updates.
+     * @return False as this oracle doesn't need updates.
+     */
+    function needsUpdate(bytes memory) public view virtual override returns (bool) {
+        return false;
+    }
+
+    /**
+     * @notice Checks if the oracle can be updated.
+     * @dev This oracle doesn't support updates.
+     * @return False as this oracle can't be updated.
+     */
+    function canUpdate(bytes memory) public view virtual override returns (bool) {
+        return false;
+    }
+
+    /**
+     * @notice Retrieves the latest observation data by consulting the underlying accumulators.
+     * @dev The observation timestamp is the oldest of the two accumulator observation timestamps.
+     * @param token The address of the token.
+     * @return observation The latest observation data.
+     */
+    function getLatestObservation(
+        address token
+    ) public view virtual override returns (ObservationLibrary.Observation memory observation) {
+        (observation.price, observation.timestamp) = readUnderlyingFeed(token);
+        observation.tokenLiquidity = 0;
+        observation.quoteTokenLiquidity = 0;
+    }
+
+    /// @inheritdoc IERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(AbstractOracle, ExplicitQuotationMetadata) returns (bool) {
+        return AbstractOracle.supportsInterface(interfaceId);
+    }
+
+    function getUnderlyingFeed() public view virtual returns (address) {
+        return venusOracle;
+    }
+
+    /// @inheritdoc AbstractOracle
+    function instantFetch(
+        address token
+    ) internal view virtual override returns (uint112 price, uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
+        (price, ) = readUnderlyingFeed(token);
+        tokenLiquidity = 0;
+        quoteTokenLiquidity = 0;
+    }
+
+    /**
+     * @notice Gets the number of decimals for a token.
+     * @dev Defaults to 18 decimals if the token does not implement the `decimals()` function or if the call fails.
+     *
+     * @param token The address of the token to get the decimals for. Use 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB
+     * for native BNB.
+     */
+    function getTokenDecimals(address token) internal view virtual returns (uint8) {
+        if (token == 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB) {
+            return 18; // Native token (BNB - 18 decimals)
+        }
+
+        (bool success, bytes memory data) = address(token).staticcall(abi.encodeWithSignature("decimals()"));
+        if (!success || data.length != 32) {
+            return 18; // Assume 18
+        }
+
+        return abi.decode(data, (uint8));
+    }
+
+    function readUnderlyingFeed(address token) internal view virtual returns (uint112 price, uint32 timestamp) {
+        uint256 workingPrice = OracleInterface(venusOracle).getPrice(token);
+        uint256 ourDecimals = quoteTokenDecimals();
+        uint256 venusFeedDecimals = 36 - getTokenDecimals(token);
+
+        // Convert the price to the quote token's decimals
+        if (venusFeedDecimals > ourDecimals) {
+            workingPrice = workingPrice / (10 ** (venusFeedDecimals - ourDecimals));
+        } else if (venusFeedDecimals < ourDecimals) {
+            workingPrice = workingPrice * (10 ** (ourDecimals - venusFeedDecimals));
+        }
+
+        if (workingPrice > type(uint112).max) {
+            revert AnswerTooLarge(workingPrice);
+        }
+
+        // Venus's oracles do not expose a timestamp, so we use the current block timestamp. We expect Venus oracles
+        // to revert if the price is not fresh enough.
+        uint256 blockTimestamp = block.timestamp;
+        if (blockTimestamp > type(uint32).max) {
+            revert InvalidTimestamp(blockTimestamp);
+        }
+
+        price = uint112(workingPrice);
+        timestamp = uint32(blockTimestamp);
+    }
+}

--- a/contracts/strategies/aggregation/AbstractAggregator.sol
+++ b/contracts/strategies/aggregation/AbstractAggregator.sol
@@ -75,6 +75,9 @@ abstract contract AbstractAggregator is IERC165, IAggregationStrategy {
 
     /**
      * @notice Calculates the final timestamp based on the provided timestamps and the configured timestamp strategy.
+     * @dev While uint256 is used for timestamps, the final timestamp is expected to be
+     * within the range of uint32, as it is stored in the Observation struct. Enforcement occurs during result
+     * preparation.
      * @param timestamps An array of timestamps from which to calculate the final timestamp. The order is expected to be
      * the same as the order of observations.
      * @return The final timestamp based on the configured strategy.

--- a/contracts/strategies/aggregation/IAggregationStrategy.sol
+++ b/contracts/strategies/aggregation/IAggregationStrategy.sol
@@ -14,6 +14,17 @@ import "../../libraries/ObservationLibrary.sol";
  */
 interface IAggregationStrategy {
     /**
+     * @notice Enum representing the strategy for determining the timestamp of the aggregated observation.
+     */
+    enum TimestampStrategy {
+        ThisBlock,
+        EarliestObservation,
+        LatestObservation,
+        FirstObservation,
+        LastObservation
+    }
+
+    /**
      * @notice Aggregate the observations within the specified range and return the result
      * as a single Observation.
      *

--- a/contracts/strategies/aggregation/MaximumAggregator.sol
+++ b/contracts/strategies/aggregation/MaximumAggregator.sol
@@ -11,6 +11,12 @@ import "../averaging/IAveragingStrategy.sol";
  */
 contract MaximumAggregator is AbstractAggregator {
     /**
+     * @notice Constructs a new MaximumAggregator instance.
+     * @param timestampStrategy_ The strategy used to handle timestamps in the aggregated observations.
+     */
+    constructor(TimestampStrategy timestampStrategy_) AbstractAggregator(timestampStrategy_) {}
+
+    /**
      * @notice Aggregates the observations by taking the maximum price and the sum of the token and quote token
      *   liquidity.
      * @param observations The observations to aggregate.
@@ -34,6 +40,8 @@ contract MaximumAggregator is AbstractAggregator {
         uint256 sumTokenLiquidity = 0;
         uint256 sumQuoteTokenLiquidity = 0;
 
+        uint256[] memory timestamps = new uint256[](to - from + 1);
+
         for (uint256 i = from; i <= to; ++i) {
             uint256 price = observations[i].data.price;
             if (price > maxPrice) {
@@ -42,8 +50,9 @@ contract MaximumAggregator is AbstractAggregator {
 
             sumTokenLiquidity += observations[i].data.tokenLiquidity;
             sumQuoteTokenLiquidity += observations[i].data.quoteTokenLiquidity;
+            timestamps[i - from] = observations[i].data.timestamp;
         }
 
-        return prepareResult(maxPrice, sumTokenLiquidity, sumQuoteTokenLiquidity);
+        return prepareResult(maxPrice, sumTokenLiquidity, sumQuoteTokenLiquidity, calculateFinalTimestamp(timestamps));
     }
 }

--- a/contracts/strategies/aggregation/MeanAggregator.sol
+++ b/contracts/strategies/aggregation/MeanAggregator.sol
@@ -20,8 +20,12 @@ contract MeanAggregator is AbstractAggregator {
     /**
      * @notice Constructor for the MeanAggregator contract.
      * @param averagingStrategy_ The averaging strategy to use for calculating the weighted mean.
+     * @param timestampStrategy_ The strategy used to handle timestamps in the aggregated observations.
      */
-    constructor(IAveragingStrategy averagingStrategy_) {
+    constructor(
+        IAveragingStrategy averagingStrategy_,
+        TimestampStrategy timestampStrategy_
+    ) AbstractAggregator(timestampStrategy_) {
         averagingStrategy = averagingStrategy_;
     }
 
@@ -51,6 +55,8 @@ contract MeanAggregator is AbstractAggregator {
         uint256 sumTokenLiquidity = 0;
         uint256 sumQuoteTokenLiquidity = 0;
 
+        uint256[] memory timestamps = new uint256[](to - from + 1);
+
         for (uint256 i = from; i <= to; ++i) {
             uint256 weight = extractWeight(observations[i].data);
 
@@ -59,13 +65,14 @@ contract MeanAggregator is AbstractAggregator {
 
             sumTokenLiquidity += observations[i].data.tokenLiquidity;
             sumQuoteTokenLiquidity += observations[i].data.quoteTokenLiquidity;
+            timestamps[i - from] = observations[i].data.timestamp;
         }
 
         if (sumWeight == 0) revert ZeroWeight();
 
         uint256 price = averagingStrategy.calculateWeightedAverage(sumWeightedPrice, sumWeight);
 
-        return prepareResult(price, sumTokenLiquidity, sumQuoteTokenLiquidity);
+        return prepareResult(price, sumTokenLiquidity, sumQuoteTokenLiquidity, calculateFinalTimestamp(timestamps));
     }
 
     /**

--- a/contracts/strategies/aggregation/MedianAggregator.sol
+++ b/contracts/strategies/aggregation/MedianAggregator.sol
@@ -16,6 +16,12 @@ contract MedianAggregator is AbstractAggregator {
     using SortingLibrary for uint112[];
 
     /**
+     * @notice Constructs a new MedianAggregator instance.
+     * @param timestampStrategy_ The strategy used to handle timestamps in the aggregated observations.
+     */
+    constructor(TimestampStrategy timestampStrategy_) AbstractAggregator(timestampStrategy_) {}
+
+    /**
      * @notice Aggregates the observations by taking the median price and the sum of the token and quote token
      * liquidity.
      *
@@ -45,11 +51,14 @@ contract MedianAggregator is AbstractAggregator {
         uint256 sumTokenLiquidity = 0;
         uint256 sumQuoteTokenLiquidity = 0;
 
+        uint256[] memory timestamps = new uint256[](to - from + 1);
+
         for (uint256 i = from; i <= to; ++i) {
             prices[i] = observations[i].data.price;
 
             sumTokenLiquidity += observations[i].data.tokenLiquidity;
             sumQuoteTokenLiquidity += observations[i].data.quoteTokenLiquidity;
+            timestamps[i - from] = observations[i].data.timestamp;
         }
 
         prices.quickSort(0, int256(length - 1));
@@ -64,6 +73,7 @@ contract MedianAggregator is AbstractAggregator {
             medianPrice = prices[medianIndex];
         }
 
-        return prepareResult(medianPrice, sumTokenLiquidity, sumQuoteTokenLiquidity);
+        return
+            prepareResult(medianPrice, sumTokenLiquidity, sumQuoteTokenLiquidity, calculateFinalTimestamp(timestamps));
     }
 }

--- a/contracts/strategies/aggregation/MedianAggregator.sol
+++ b/contracts/strategies/aggregation/MedianAggregator.sol
@@ -42,8 +42,15 @@ contract MedianAggregator is AbstractAggregator {
         if (observations.length <= to) revert InsufficientObservations(observations.length, to - from + 1);
         uint256 length = to - from + 1;
         if (length == 1) {
+            uint256[] memory timestamps_ = new uint256[](1);
+            timestamps_[0] = observations[from].data.timestamp;
+            uint256 finalTimestamp = calculateFinalTimestamp(timestamps_);
+            if (finalTimestamp > type(uint32).max) {
+                revert InvalidTimestamp(finalTimestamp);
+            }
+
             ObservationLibrary.Observation memory observation = observations[from].data;
-            observation.timestamp = uint32(block.timestamp);
+            observation.timestamp = uint32(finalTimestamp);
             return observation;
         }
 

--- a/contracts/strategies/aggregation/MinimumAggregator.sol
+++ b/contracts/strategies/aggregation/MinimumAggregator.sol
@@ -11,6 +11,12 @@ import "../averaging/IAveragingStrategy.sol";
  */
 contract MinimumAggregator is AbstractAggregator {
     /**
+     * @notice Constructs a new MinimumAggregator instance.
+     * @param timestampStrategy_ The strategy used to handle timestamps in the aggregated observations.
+     */
+    constructor(TimestampStrategy timestampStrategy_) AbstractAggregator(timestampStrategy_) {}
+
+    /**
      * @notice Aggregates the observations by taking the minimum price and the sum of the token and quote token
      *   liquidity.
      * @param observations The observations to aggregate.
@@ -34,6 +40,8 @@ contract MinimumAggregator is AbstractAggregator {
         uint256 sumTokenLiquidity = 0;
         uint256 sumQuoteTokenLiquidity = 0;
 
+        uint256[] memory timestamps = new uint256[](to - from + 1);
+
         for (uint256 i = from; i <= to; ++i) {
             uint256 price = observations[i].data.price;
             if (price < minPrice) {
@@ -42,8 +50,9 @@ contract MinimumAggregator is AbstractAggregator {
 
             sumTokenLiquidity += observations[i].data.tokenLiquidity;
             sumQuoteTokenLiquidity += observations[i].data.quoteTokenLiquidity;
+            timestamps[i - from] = observations[i].data.timestamp;
         }
 
-        return prepareResult(minPrice, sumTokenLiquidity, sumQuoteTokenLiquidity);
+        return prepareResult(minPrice, sumTokenLiquidity, sumQuoteTokenLiquidity, calculateFinalTimestamp(timestamps));
     }
 }

--- a/contracts/strategies/aggregation/QuoteTokenWeightedMeanAggregator.sol
+++ b/contracts/strategies/aggregation/QuoteTokenWeightedMeanAggregator.sol
@@ -12,8 +12,12 @@ contract QuoteTokenWeightedMeanAggregator is MeanAggregator {
     /**
      * @notice Constructor for the QuoteTokenWeightedMeanAggregator contract.
      * @param averagingStrategy_ The averaging strategy to use for calculating the weighted mean.
+     * @param timestampStrategy_ The strategy used to handle timestamps in the aggregated observations.
      */
-    constructor(IAveragingStrategy averagingStrategy_) MeanAggregator(averagingStrategy_) {}
+    constructor(
+        IAveragingStrategy averagingStrategy_,
+        TimestampStrategy timestampStrategy_
+    ) MeanAggregator(averagingStrategy_, timestampStrategy_) {}
 
     /**
      * @notice Extracts the weight from the provided observation using the quote token liquidity.

--- a/contracts/strategies/aggregation/TokenWeightedMeanAggregator.sol
+++ b/contracts/strategies/aggregation/TokenWeightedMeanAggregator.sol
@@ -12,8 +12,12 @@ contract TokenWeightedMeanAggregator is MeanAggregator {
     /**
      * @notice Constructor for the TokenWeightedMeanAggregator contract.
      * @param averagingStrategy_ The averaging strategy to use for calculating the weighted mean.
+     * @param timestampStrategy_ The strategy used to handle timestamps in the aggregated observations.
      */
-    constructor(IAveragingStrategy averagingStrategy_) MeanAggregator(averagingStrategy_) {}
+    constructor(
+        IAveragingStrategy averagingStrategy_,
+        TimestampStrategy timestampStrategy_
+    ) MeanAggregator(averagingStrategy_, timestampStrategy_) {}
 
     /**
      * @notice Extracts the weight from the provided observation using the token liquidity.

--- a/contracts/test/DefaultAggregator.sol
+++ b/contracts/test/DefaultAggregator.sol
@@ -5,7 +5,7 @@ import "../strategies/averaging/HarmonicAveragingWS140.sol";
 import "../strategies/aggregation/QuoteTokenWeightedMeanAggregator.sol";
 
 contract DefaultAggregator is QuoteTokenWeightedMeanAggregator, HarmonicAveragingWS140 {
-    constructor() QuoteTokenWeightedMeanAggregator(this) {}
+    constructor() QuoteTokenWeightedMeanAggregator(this, TimestampStrategy.ThisBlock) {}
 
     function supportsInterface(
         bytes4 interfaceId

--- a/contracts/test/DefaultAggregator2.sol
+++ b/contracts/test/DefaultAggregator2.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.13;
+
+import "../strategies/averaging/HarmonicAveragingWS140.sol";
+import "../strategies/aggregation/QuoteTokenWeightedMeanAggregator.sol";
+
+contract DefaultAggregator2 is QuoteTokenWeightedMeanAggregator, HarmonicAveragingWS140 {
+    constructor(TimestampStrategy timestampStrategy) QuoteTokenWeightedMeanAggregator(this, timestampStrategy) {}
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(AbstractAggregator, AbstractAveraging) returns (bool) {
+        return AbstractAggregator.supportsInterface(interfaceId) || AbstractAveraging.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/test/Erc20InvalidDecimalFunc.sol
+++ b/contracts/test/Erc20InvalidDecimalFunc.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.13;
+
+contract Erc20InvalidDecimalFunc {
+    constructor() {}
+
+    function decimals() external pure returns (uint256, uint256) {
+        return (2, 3);
+    }
+}

--- a/contracts/test/Erc20NoDecimalFunc.sol
+++ b/contracts/test/Erc20NoDecimalFunc.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.13;
+
+contract Erc20NoDecimalFunc {
+    constructor() {}
+}

--- a/contracts/test/VenusOracleStub.sol
+++ b/contracts/test/VenusOracleStub.sol
@@ -1,0 +1,75 @@
+//SPDX-License-Identifier: MIT
+pragma solidity =0.8.13;
+
+import {OracleInterface} from "../oracles/views/VenusOracleView.sol";
+
+contract VenusOracleStub is OracleInterface {
+    uint8 public decimals;
+
+    mapping(address => bool) public hasPrice;
+    mapping(address => uint256) public prices;
+
+    address internal immutable defaultFeedToken;
+
+    constructor(address feedToken_, uint8 _decimals) {
+        defaultFeedToken = feedToken_;
+        decimals = _decimals;
+    }
+
+    function setPrice(address token, uint256 price) public {
+        // Convert the price to the Venus format (decimals = 36 - tokenDecimals)
+
+        uint256 tokenDecimals = getTokenDecimals(token);
+
+        uint256 venusDecimals = 36 - tokenDecimals;
+
+        if (venusDecimals > decimals) {
+            // Increase the price to match the expected decimals
+            price = price * (10 ** (venusDecimals - decimals));
+        } else if (venusDecimals < decimals) {
+            // Decrease the price to match the expected decimals
+            price = price / (10 ** (decimals - venusDecimals));
+        }
+
+        prices[token] = price;
+        hasPrice[token] = true;
+    }
+
+    function setRoundDataNow(uint256 price) public {
+        // Set the price for the default feed token
+        setPrice(defaultFeedToken, price);
+    }
+
+    function setRoundData(uint80, uint256 answer_, uint256, uint256, uint80) public {
+        // Set the price for the default feed token
+        setPrice(defaultFeedToken, answer_);
+    }
+
+    function getPrice(address asset) external view override returns (uint256) {
+        if (!hasPrice[asset]) {
+            revert("UnsupportedToken");
+        }
+
+        return prices[asset];
+    }
+
+    /**
+     * @notice Gets the number of decimals for a token.
+     * @dev Defaults to 18 decimals if the token does not implement the `decimals()` function or if the call fails.
+     *
+     * @param token The address of the token to get the decimals for. Use 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB
+     * for native BNB.
+     */
+    function getTokenDecimals(address token) internal view virtual returns (uint8) {
+        if (token == 0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB) {
+            return 18; // Native token (BNB - 18 decimals)
+        }
+
+        (bool success, bytes memory data) = address(token).staticcall(abi.encodeWithSignature("decimals()"));
+        if (!success || data.length != 32) {
+            return 18; // Assume 18
+        }
+
+        return abi.decode(data, (uint8));
+    }
+}

--- a/contracts/test/accumulators/AdrastiaUtilizationAndErrorAccumulatorStub.sol
+++ b/contracts/test/accumulators/AdrastiaUtilizationAndErrorAccumulatorStub.sol
@@ -35,7 +35,7 @@ contract AdrastiaUtilizationAndErrorAccumulatorStub is AdrastiaUtilizationAndErr
     }
 
     function stubFetchValue(address token) public view returns (uint112) {
-        return fetchValue(abi.encode(token));
+        return fetchValue(abi.encode(token), _heartbeat());
     }
 
     function stubFetchTarget(address token) public view returns (uint112) {

--- a/contracts/test/accumulators/AlocUtilizationAndErrorAccumulatorStub.sol
+++ b/contracts/test/accumulators/AlocUtilizationAndErrorAccumulatorStub.sol
@@ -33,7 +33,7 @@ contract AlocUtilizationAndErrorAccumulatorStub is AlocUtilizationAndErrorAccumu
     }
 
     function stubFetchValue(address token) public view returns (uint112) {
-        return fetchValue(abi.encode(token));
+        return fetchValue(abi.encode(token), 0);
     }
 
     function stubFetchTarget(address token) public view returns (uint112) {

--- a/contracts/test/accumulators/LiquidityAccumulatorStub.sol
+++ b/contracts/test/accumulators/LiquidityAccumulatorStub.sol
@@ -137,7 +137,8 @@ contract LiquidityAccumulatorStub is LiquidityAccumulator {
     }
 
     function fetchLiquidity(
-        bytes memory data
+        bytes memory data,
+        uint256 /* maxAge */ // maxAge is not used in this implementation
     ) internal view virtual override returns (uint112 tokenLiquidity, uint112 quoteTokenLiquidity) {
         address token = abi.decode(data, (address));
 

--- a/contracts/test/accumulators/PriceAccumulatorStub.sol
+++ b/contracts/test/accumulators/PriceAccumulatorStub.sol
@@ -97,7 +97,7 @@ contract PriceAccumulatorStub is PriceAccumulator {
         else return super.validateObservation(updateData, price);
     }
 
-    function fetchPrice(bytes memory data) internal view virtual override returns (uint112) {
+    function fetchPrice(bytes memory data, uint256 /* maxAge */) internal view virtual override returns (uint112) {
         address token = abi.decode(data, (address));
 
         return mockPrices[token];

--- a/contracts/test/accumulators/VenusSBAccumulatorStub.sol
+++ b/contracts/test/accumulators/VenusSBAccumulatorStub.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.13;
 
-import "../../accumulators/proto/venus/VenusIsolatedSBAccumulator.sol";
+import "../../accumulators/proto/venus/VenusSBAccumulator.sol";
 
-contract VenusIsolatedSBAccumulatorStub is VenusIsolatedSBAccumulator {
+contract VenusSBAccumulatorStub is VenusSBAccumulator {
     constructor(
         IAveragingStrategy averagingStrategy_,
         address comptroller_,
@@ -12,7 +12,7 @@ contract VenusIsolatedSBAccumulatorStub is VenusIsolatedSBAccumulator {
         uint256 minUpdateDelay_,
         uint256 maxUpdateDelay_
     )
-        VenusIsolatedSBAccumulator(
+        VenusSBAccumulator(
             averagingStrategy_,
             comptroller_,
             decimals_,

--- a/contracts/test/oracles/MockOracle.sol
+++ b/contracts/test/oracles/MockOracle.sol
@@ -71,6 +71,20 @@ contract MockOracle is AbstractOracle {
         observation.timestamp = timestamp;
     }
 
+    function stubSetObservationNow(
+        address token,
+        uint112 price,
+        uint112 tokenLiquidity,
+        uint112 quoteTokenLiquidity
+    ) public {
+        ObservationLibrary.Observation storage observation = observations[token];
+
+        observation.price = price;
+        observation.tokenLiquidity = tokenLiquidity;
+        observation.quoteTokenLiquidity = quoteTokenLiquidity;
+        observation.timestamp = uint32(block.timestamp);
+    }
+
     function stubSetInstantRates(
         address token,
         uint112 price,

--- a/contracts/test/strategies/aggregation/AggregatorStub.sol
+++ b/contracts/test/strategies/aggregation/AggregatorStub.sol
@@ -12,13 +12,15 @@ contract AggregatorStub is AbstractAggregator {
 
     Config public config;
 
+    constructor() AbstractAggregator(TimestampStrategy.ThisBlock) {}
+
     function aggregateObservations(
         address,
         ObservationLibrary.MetaObservation[] calldata,
         uint256,
         uint256
     ) external view override returns (ObservationLibrary.Observation memory) {
-        return prepareResult(config.price, config.tokenLiquidity, config.quoteTokenLiquidity);
+        return prepareResult(config.price, config.tokenLiquidity, config.quoteTokenLiquidity, block.timestamp);
     }
 
     function stubSetObservation(uint256 price, uint256 tokenLiquidity, uint256 quoteTokenLiquidity) public {

--- a/contracts/test/strategies/aggregation/AggregatorStub.sol
+++ b/contracts/test/strategies/aggregation/AggregatorStub.sol
@@ -8,11 +8,20 @@ contract AggregatorStub is AbstractAggregator {
         uint256 price;
         uint256 tokenLiquidity;
         uint256 quoteTokenLiquidity;
+        uint256 timestamp;
     }
 
     Config public config;
 
-    constructor() AbstractAggregator(TimestampStrategy.ThisBlock) {}
+    constructor(TimestampStrategy timestampStrategy_) AbstractAggregator(timestampStrategy_) {}
+
+    function stubValidateTimestampStrategy(uint8 strategy) public pure {
+        validateTimestampStrategy(TimestampStrategy(strategy));
+    }
+
+    function stubCalculateFinalTimestamp(uint256[] memory timestamps) public view returns (uint256) {
+        return calculateFinalTimestamp(timestamps);
+    }
 
     function aggregateObservations(
         address,
@@ -20,12 +29,18 @@ contract AggregatorStub is AbstractAggregator {
         uint256,
         uint256
     ) external view override returns (ObservationLibrary.Observation memory) {
-        return prepareResult(config.price, config.tokenLiquidity, config.quoteTokenLiquidity, block.timestamp);
+        return prepareResult(config.price, config.tokenLiquidity, config.quoteTokenLiquidity, config.timestamp);
     }
 
-    function stubSetObservation(uint256 price, uint256 tokenLiquidity, uint256 quoteTokenLiquidity) public {
+    function stubSetObservation(
+        uint256 price,
+        uint256 tokenLiquidity,
+        uint256 quoteTokenLiquidity,
+        uint256 timestamp
+    ) public {
         config.price = price;
         config.tokenLiquidity = tokenLiquidity;
         config.quoteTokenLiquidity = quoteTokenLiquidity;
+        config.timestamp = timestamp;
     }
 }

--- a/forking.js
+++ b/forking.js
@@ -1,0 +1,4 @@
+export default {
+    url: process.env.ETHEREUM_URL || "",
+    blockNumber: 20370000,
+};

--- a/forking.js
+++ b/forking.js
@@ -1,4 +1,4 @@
 export default {
     url: process.env.ETHEREUM_URL || "",
-    blockNumber: 20370000,
+    blockNumber: 22818900,
 };

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -53,7 +53,7 @@ module.exports = {
             hardfork: process.env.HARDHAT_HARDFORK || "berlin",
             forking: {
                 url: process.env.ETHEREUM_URL || "",
-                // blockNumber: 22675000,
+                blockNumber: 20370000,
             },
             mining: {
                 auto: true,

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -7,6 +7,8 @@ require("@atixlabs/hardhat-time-n-mine");
 require("hardhat-contract-sizer");
 require("@nomiclabs/hardhat-etherscan");
 
+const forkingConfig = require("./forking").default;
+
 const SOLC_8 = {
     version: "0.8.13",
     settings: {
@@ -51,10 +53,7 @@ module.exports = {
         hardhat: {
             gas: 10000000,
             hardfork: process.env.HARDHAT_HARDFORK || "berlin",
-            forking: {
-                url: process.env.ETHEREUM_URL || "",
-                blockNumber: 20370000,
-            },
+            forking: forkingConfig,
             mining: {
                 auto: true,
                 mempool: {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -50,10 +50,10 @@ module.exports = {
     networks: {
         hardhat: {
             gas: 10000000,
-            hardfork: process.env.HARDHAT_HARDFORK || "cancun",
+            hardfork: process.env.HARDHAT_HARDFORK || "berlin",
             forking: {
                 url: process.env.ETHEREUM_URL || "",
-                blockNumber: 20370000,
+                // blockNumber: 22675000,
             },
             mining: {
                 auto: true,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@atixlabs/hardhat-time-n-mine": "^0.0.5",
-    "@nomiclabs/hardhat-ethers": "^2.2.1",
+    "@nomiclabs/hardhat-ethers": "^2.2.3",
     "@nomiclabs/hardhat-etherscan": "^3.1.7",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
     "@uniswap/v3-periphery": "^1.4.3",
@@ -46,16 +46,16 @@
     "dotenv": "^16.3.1",
     "eth-gas-reporter": "^0.2.25",
     "ethereum-waffle": "4.0.0-alpha.0",
-    "ethers": "^5.7.2",
-    "hardhat": "2.22.3",
+    "ethers": "^5.8.0",
+    "hardhat": "2.24.2",
     "hardhat-contract-sizer": "^2.10.0",
-    "hardhat-gas-reporter": "^1.0.9",
-    "hardhat-tracer": "^2.8.2",
+    "hardhat-gas-reporter": "^2.3.0",
+    "hardhat-tracer": "^3.2.1",
     "prettier": "^2.7.1",
     "prettier-plugin-solidity": "^1.0.0-rc.1",
     "solhint": "^3.3.7",
     "solhint-plugin-prettier": "^0.0.5",
-    "solidity-coverage": "^0.8.3"
+    "solidity-coverage": "^0.8.16"
   },
   "scripts": {
     "compile": "hardhat compile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrastia-oracle/adrastia-core",
-  "version": "4.9.1",
+  "version": "4.10.0",
   "main": "index.js",
   "author": "TRILEZ SOFTWARE INC.",
   "license": "BUSL-1.1",

--- a/scripts/consult-aggregator-otf.js
+++ b/scripts/consult-aggregator-otf.js
@@ -1,0 +1,173 @@
+// We require the Hardhat Runtime Environment explicitly here. This is optional
+// but useful for running the script in a standalone fashion through `node <script>`.
+//
+// When running the script with `hardhat run <script>` you'll find the Hardhat
+// Runtime Environment's members available in the global scope.
+const hre = require("hardhat");
+
+const ethers = hre.ethers;
+
+const wethAddress = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+const wethFeedAddress = "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419";
+
+const AGGREGATION_TIMESTAMP_STRATEGY_LATESTOBSERVATION = 2;
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function createContract(name, ...deploymentArgs) {
+    const contractFactory = await ethers.getContractFactory(name);
+
+    const contract = await contractFactory.deploy(...deploymentArgs);
+
+    await contract.deployed();
+
+    return contract;
+}
+
+async function currentBlockTimestamp() {
+    const currentBlockNumber = await ethers.provider.getBlockNumber();
+
+    return await blockTimestamp(currentBlockNumber);
+}
+
+async function blockTimestamp(blockNum) {
+    return (await ethers.provider.getBlock(blockNum)).timestamp;
+}
+
+async function createChainlinkOracleView(feedAddress, tokenAddress, quoteTokenAddress) {
+    const oracle = await createContract("ChainlinkOracleView", feedAddress, tokenAddress, quoteTokenAddress);
+
+    return {
+        oracle: oracle,
+    };
+}
+
+async function createOtfAggregatorOracle(
+    quoteTokenName,
+    quoteTokenAddress,
+    quoteTokenSymbol,
+    quoteTokenDecimals,
+    liquidityDecimals,
+    oracles,
+    tokenSpecificOracles
+) {
+    const aggregationStrategy = await createContract(
+        "MinimumAggregator",
+        AGGREGATION_TIMESTAMP_STRATEGY_LATESTOBSERVATION
+    );
+
+    return await createContract(
+        "OtfAggregatorOracle",
+        {
+            aggregationStrategy: aggregationStrategy.address,
+            validationStrategy: ethers.constants.AddressZero, // No validation strategy
+            quoteTokenName,
+            quoteTokenAddress,
+            quoteTokenSymbol,
+            quoteTokenDecimals,
+            liquidityDecimals,
+            oracles,
+            tokenSpecificOracles,
+        },
+        86400, // min freshness - 24 hours
+        1 // minimum responses
+    );
+}
+
+async function main() {
+    const token = wethAddress;
+    const quoteToken = ethers.constants.AddressZero;
+    const feed = wethFeedAddress;
+    const liquidityDecimals = 0; // Liquidity not supported
+
+    const chainlinkOracle = await createChainlinkOracleView(feed, token, quoteToken);
+
+    console.log("Chainlink Oracle Address =", chainlinkOracle.oracle.address);
+
+    const oracles = [chainlinkOracle.oracle.address];
+
+    const tokenSpecificOracles = [];
+
+    const oracle = await createOtfAggregatorOracle(
+        "USD Coin",
+        quoteToken,
+        "USDC",
+        6,
+        liquidityDecimals,
+        oracles,
+        tokenSpecificOracles
+    );
+
+    console.log("OtfAggregatorOracle Address =", oracle.address);
+
+    const tokenContract = await ethers.getContractAt("ERC20", token);
+
+    const tokenSymbol = await tokenContract.symbol();
+    const tokenDecimals = await tokenContract.decimals();
+
+    const quoteTokenSymbol = await oracle.quoteTokenSymbol();
+    const quoteTokenDecimals = await oracle.quoteTokenDecimals();
+
+    var lastConsultGas = 0;
+
+    const updateData = ethers.utils.hexZeroPad(token, 32);
+
+    console.log("Update data =", updateData);
+
+    while (true) {
+        try {
+            const consultGas = await oracle.estimateGas["consult(address)"](token);
+
+            if (!consultGas.eq(lastConsultGas)) {
+                console.log("\u001b[" + 93 + "m" + "Consult gas used = " + consultGas + "\u001b[0m");
+
+                lastConsultGas = consultGas;
+            }
+
+            const consultation = await oracle["consult(address)"](token);
+
+            const priceStr = ethers.utils.commify(ethers.utils.formatUnits(consultation["price"], quoteTokenDecimals));
+
+            console.log(
+                "\u001b[" + 32 + "m" + "Price(%s) = %s %s" + "\u001b[0m",
+                tokenSymbol,
+                priceStr,
+                quoteTokenSymbol
+            );
+
+            const tokenLiquidityStr = ethers.utils.commify(
+                ethers.utils.formatUnits(consultation["tokenLiquidity"], liquidityDecimals)
+            );
+
+            const quoteTokenLiquidityStr = ethers.utils.commify(
+                ethers.utils.formatUnits(consultation["quoteTokenLiquidity"], liquidityDecimals)
+            );
+
+            console.log(
+                "\u001b[" + 31 + "m" + "Liquidity(%s) = %s, Liquidity(%s) = %s" + "\u001b[0m",
+                tokenSymbol,
+                tokenLiquidityStr,
+                quoteTokenSymbol,
+                quoteTokenLiquidityStr
+            );
+        } catch (e) {
+            console.log(e);
+        }
+
+        await sleep(1000);
+
+        // Keep mining blocks so that block.timestamp updates
+        await hre.network.provider.send("evm_mine");
+    }
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/scripts/consult-venus-oracle-view.js
+++ b/scripts/consult-venus-oracle-view.js
@@ -1,0 +1,86 @@
+const hre = require("hardhat");
+
+const ethers = hre.ethers;
+
+const ETHEREUM_ORACLE = "0xd2ce3fb018805ef92b8C5976cb31F84b4E295F94";
+
+const ETHEREUM_WETH = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+const ETHEREUM_USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function createContract(name, ...deploymentArgs) {
+    const contractFactory = await ethers.getContractFactory(name);
+
+    const contract = await contractFactory.deploy(...deploymentArgs);
+
+    await contract.deployed();
+
+    return contract;
+}
+
+async function createVenusOracleView(
+    oracleAddress,
+    quoteTokenName,
+    quoteTokenAddress,
+    quoteTokenSymbol,
+    quoteTokenDecimals
+) {
+    const oracle = await createContract(
+        "VenusOracleView",
+        oracleAddress,
+        quoteTokenName,
+        quoteTokenAddress,
+        quoteTokenSymbol,
+        quoteTokenDecimals
+    );
+
+    return {
+        oracle: oracle,
+    };
+}
+
+async function main() {
+    const token = ETHEREUM_USDC;
+
+    const quoteTokenDecimals = 18;
+
+    const oracle = await createVenusOracleView(
+        ETHEREUM_ORACLE,
+        "USD",
+        ethers.constants.AddressZero,
+        "USD",
+        quoteTokenDecimals
+    );
+
+    const tokenContract = await ethers.getContractAt("ERC20", token);
+    const tokenSymbol = await tokenContract.symbol();
+
+    while (true) {
+        const price = await oracle.oracle["consultPrice(address)"](token);
+
+        // Convert to a human-readable format
+        const priceFormatted = ethers.utils.commify(ethers.utils.formatUnits(price, quoteTokenDecimals));
+
+        console.log("\u001b[" + 32 + "m" + "Price(%s) = %s" + "\u001b[0m", tokenSymbol, priceFormatted);
+
+        await sleep(1000);
+
+        const consultGas = await oracle.oracle.estimateGas["consultPrice(address)"](token);
+        console.log("\u001b[" + 33 + "m" + "Gas used for consultPrice: %s" + "\u001b[0m", consultGas.toString());
+
+        // Keep mining blocks so that block.timestamp updates
+        await hre.network.provider.send("evm_mine");
+    }
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/test/liquidity-accumulator/adrastia-utilization-and-error.js
+++ b/test/liquidity-accumulator/adrastia-utilization-and-error.js
@@ -1,7 +1,7 @@
 const { BigNumber } = require("ethers");
 const { expect } = require("chai");
-const { ethers } = require("hardhat");
-const { blockTimestamp } = require("../../src/time");
+const { ethers, timeAndMine } = require("hardhat");
+const { blockTimestamp, currentBlockTimestamp } = require("../../src/time");
 
 const AddressZero = ethers.constants.AddressZero;
 
@@ -89,7 +89,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchValue - Considering empty 
     });
 
     it("Returns 100% utilization when the market is at zero utilization but has no liquidity", async function () {
-        await sbOracle.stubSetObservation(USDC, 0, 0, 0, 1);
+        await sbOracle.stubSetObservationNow(USDC, 0, 0, 0);
 
         const utilization = await accumulator.stubFetchValue(USDC);
         const expectedUtilization = ethers.utils.parseUnits("1", DEFAULT_DECIMALS);
@@ -100,7 +100,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchValue - Considering empty 
     it("Returns 0% utilization when the market is at zero utilization but has liquidity", async function () {
         const totalBorrow = 0;
         const totalSupply = ethers.utils.parseUnits("1", DEFAULT_DECIMALS);
-        await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+        await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
         const utilization = await accumulator.stubFetchValue(USDC);
         const expectedUtilization = ethers.utils.parseUnits("0", DEFAULT_DECIMALS);
@@ -111,7 +111,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchValue - Considering empty 
     it("Returns 1% utilization when the market is at 1% utilization", async function () {
         const totalBorrow = ethers.utils.parseUnits("1", DEFAULT_DECIMALS);
         const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
-        await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+        await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
         const utilization = await accumulator.stubFetchValue(USDC);
         const expectedUtilization = ethers.utils.parseUnits("0.01", DEFAULT_DECIMALS);
@@ -122,7 +122,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchValue - Considering empty 
     it("Returns 50% utilization when the market is at 50% utilization", async function () {
         const totalBorrow = ethers.utils.parseUnits("50", DEFAULT_DECIMALS);
         const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
-        await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+        await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
         const utilization = await accumulator.stubFetchValue(USDC);
         const expectedUtilization = ethers.utils.parseUnits("0.5", DEFAULT_DECIMALS);
@@ -135,7 +135,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchValue - Considering empty 
 
         const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
         const totalBorrow = DEFAULT_TARGET.mul(totalSupply).div(BigNumber.from(10).pow(DEFAULT_DECIMALS));
-        await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+        await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
         const utilization = await accumulator.stubFetchValue(USDC);
         const expectedUtilization = ethers.utils.parseUnits(utilizationStr, DEFAULT_DECIMALS);
@@ -148,7 +148,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchValue - Considering empty 
 
         const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
         const totalBorrow = totalSupply;
-        await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+        await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
         const utilization = await accumulator.stubFetchValue(USDC);
         const expectedUtilization = ethers.utils.parseUnits(utilizationStr, DEFAULT_DECIMALS);
@@ -184,7 +184,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchValue - Considering empty 
     });
 
     it("Returns 0% utilization when the market is at zero utilization but has no liquidity", async function () {
-        await sbOracle.stubSetObservation(USDC, 0, 0, 0, 1);
+        await sbOracle.stubSetObservationNow(USDC, 0, 0, 0);
 
         const utilization = await accumulator.stubFetchValue(USDC);
         const expectedUtilization = ethers.utils.parseUnits("0", DEFAULT_DECIMALS);
@@ -195,7 +195,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchValue - Considering empty 
     it("Returns 0% utilization when the market is at zero utilization but has liquidity", async function () {
         const totalBorrow = 0;
         const totalSupply = ethers.utils.parseUnits("1", DEFAULT_DECIMALS);
-        await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+        await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
         const utilization = await accumulator.stubFetchValue(USDC);
         const expectedUtilization = ethers.utils.parseUnits("0", DEFAULT_DECIMALS);
@@ -206,7 +206,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchValue - Considering empty 
     it("Returns 1% utilization when the market is at 1% utilization", async function () {
         const totalBorrow = ethers.utils.parseUnits("1", DEFAULT_DECIMALS);
         const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
-        await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+        await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
         const utilization = await accumulator.stubFetchValue(USDC);
         const expectedUtilization = ethers.utils.parseUnits("0.01", DEFAULT_DECIMALS);
@@ -219,7 +219,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchValue - Considering empty 
 
         const totalBorrow = ethers.utils.parseUnits("50", DEFAULT_DECIMALS);
         const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
-        await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+        await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
         const utilization = await accumulator.stubFetchValue(USDC);
         const expectedUtilization = ethers.utils.parseUnits(utilizationStr, DEFAULT_DECIMALS);
@@ -232,7 +232,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchValue - Considering empty 
 
         const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
         const totalBorrow = DEFAULT_TARGET.mul(totalSupply).div(BigNumber.from(10).pow(DEFAULT_DECIMALS));
-        await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+        await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
         const utilization = await accumulator.stubFetchValue(USDC);
         const expectedUtilization = ethers.utils.parseUnits(utilizationStr, DEFAULT_DECIMALS);
@@ -245,7 +245,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchValue - Considering empty 
 
         const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
         const totalBorrow = totalSupply;
-        await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+        await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
         const utilization = await accumulator.stubFetchValue(USDC);
         const expectedUtilization = ethers.utils.parseUnits(utilizationStr, DEFAULT_DECIMALS);
@@ -302,7 +302,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchLiquidity", function () {
         async function () {
             const totalBorrow = 0;
             const totalSupply = 0;
-            await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+            await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
             const [utilization, error] = await accumulator.stubFetchLiquidity(USDC);
             const expectedUtilization = ethers.utils.parseUnits("1", DEFAULT_DECIMALS);
@@ -324,7 +324,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchLiquidity", function () {
         async function () {
             const totalBorrow = 0;
             const totalSupply = ethers.utils.parseUnits("1", DEFAULT_DECIMALS);
-            await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+            await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
             const [utilization, error] = await accumulator.stubFetchLiquidity(USDC);
             const expectedUtilization = ethers.utils.parseUnits("0", DEFAULT_DECIMALS);
@@ -348,7 +348,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchLiquidity", function () {
 
             const totalBorrow = ethers.utils.parseUnits("1", DEFAULT_DECIMALS);
             const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
-            await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+            await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
             const [utilization, error] = await accumulator.stubFetchLiquidity(USDC);
             const expectedUtilization = ethers.utils.parseUnits(utilizationStr, DEFAULT_DECIMALS);
@@ -372,7 +372,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchLiquidity", function () {
 
             const totalBorrow = ethers.utils.parseUnits("50", DEFAULT_DECIMALS);
             const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
-            await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+            await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
             const [utilization, error] = await accumulator.stubFetchLiquidity(USDC);
             const expectedUtilization = ethers.utils.parseUnits(utilizationStr, DEFAULT_DECIMALS);
@@ -394,7 +394,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchLiquidity", function () {
         async function () {
             const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
             const totalBorrow = DEFAULT_TARGET.mul(totalSupply).div(BigNumber.from(10).pow(DEFAULT_DECIMALS));
-            await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+            await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
             const [utilization, error] = await accumulator.stubFetchLiquidity(USDC);
             const expectedUtilization = DEFAULT_TARGET;
@@ -403,6 +403,51 @@ describe("AdrastiaUtilizationAndErrorAccumulator#fetchLiquidity", function () {
             expect(error).to.eq(ERROR_TARGET);
         }
     );
+});
+
+describe("AdrastiaUtilizationAndErrorAccumulator#consultLiquidity(token,maxAge=0)", function () {
+    var sbOracle;
+    var accumulator;
+
+    beforeEach(async function () {
+        const sbOracleStubFactory = await ethers.getContractFactory("MockOracle");
+        const averagingStrategyFactory = await ethers.getContractFactory("ArithmeticAveraging");
+        const accumulatorFactory = await ethers.getContractFactory("AdrastiaUtilizationAndErrorAccumulatorStub");
+
+        sbOracle = await sbOracleStubFactory.deploy(AddressZero);
+        await sbOracle.deployed();
+        const averagingStrategy = await averagingStrategyFactory.deploy();
+        accumulator = await accumulatorFactory.deploy(
+            sbOracle.address,
+            true,
+            DEFAULT_TARGET,
+            averagingStrategy.address,
+            DEFAULT_DECIMALS,
+            DEFAULT_UPDATE_THRESHOLD,
+            DEFAULT_UPDATE_DELAY,
+            DEFAULT_HEARTBEAT
+        );
+
+        await accumulator.deployed();
+    });
+
+    it("Retrieves the instant utilization and error", async function () {
+        await timeAndMine.setTimeIncrease(1);
+
+        const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
+        const totalBorrow = ethers.utils.parseUnits("90", DEFAULT_DECIMALS);
+        await sbOracle.stubSetInstantRates(USDC, 0, totalBorrow, totalSupply);
+
+        // Consult the liquidity
+        const [utilization, error] = await accumulator["consultLiquidity(address,uint256)"](USDC, 0);
+
+        // Calculate expected values
+        const expectedUtilization = totalBorrow.mul(BigNumber.from(10).pow(DEFAULT_DECIMALS)).div(totalSupply);
+        const expectedError = calculateError(expectedUtilization, DEFAULT_TARGET);
+
+        expect(utilization).to.equal(expectedUtilization);
+        expect(error).to.equal(expectedError);
+    });
 });
 
 describe("AdrastiaUtilizationAndErrorAccumulator#update", function () {
@@ -435,7 +480,7 @@ describe("AdrastiaUtilizationAndErrorAccumulator#update", function () {
         // Set the SB oracle observation
         const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
         const totalBorrow = ethers.utils.parseUnits("90", DEFAULT_DECIMALS);
-        await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, 1);
+        await sbOracle.stubSetObservationNow(USDC, 0, totalBorrow, totalSupply);
 
         // Update the accumulator
         const updateData = ethers.utils.defaultAbiCoder.encode(["address"], [USDC]);
@@ -457,5 +502,52 @@ describe("AdrastiaUtilizationAndErrorAccumulator#update", function () {
         await expect(updateTx)
             .to.emit(accumulator, "Updated")
             .withArgs(USDC, expectedUtilization, expectedError, timestamp);
+    });
+
+    it("Updates successfully when the underlying observation is just fresh enough", async function () {
+        await timeAndMine.setTimeIncrease(1);
+
+        // Set the SB oracle observation
+        const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
+        const totalBorrow = ethers.utils.parseUnits("90", DEFAULT_DECIMALS);
+        // The observation will be DEFAULT_HEARTBEAT seconds old when update is called
+        const oTimestamp = (await currentBlockTimestamp()) - DEFAULT_HEARTBEAT + 2;
+        await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, oTimestamp);
+
+        // Update the accumulator
+        const updateData = ethers.utils.defaultAbiCoder.encode(["address"], [USDC]);
+        const updateTx = await accumulator.update(updateData);
+
+        // Wait for the transaction to be mined
+        const updateReceipt = await updateTx.wait();
+
+        // Get the mined block number
+        const blockNumber = updateReceipt.blockNumber;
+        const timestamp = await blockTimestamp(blockNumber);
+
+        // Calculate the expected utilization
+        const expectedUtilization = totalBorrow.mul(BigNumber.from(10).pow(DEFAULT_DECIMALS)).div(totalSupply);
+        // Calculate the expected error
+        const expectedError = calculateError(expectedUtilization, DEFAULT_TARGET);
+
+        // Ensure that the Updated event was emitted
+        await expect(updateTx)
+            .to.emit(accumulator, "Updated")
+            .withArgs(USDC, expectedUtilization, expectedError, timestamp);
+    });
+
+    it("Reverts when the underlying observation is too old", async function () {
+        await timeAndMine.setTimeIncrease(1);
+
+        // Set the SB oracle observation
+        const totalSupply = ethers.utils.parseUnits("100", DEFAULT_DECIMALS);
+        const totalBorrow = ethers.utils.parseUnits("90", DEFAULT_DECIMALS);
+        // The observation will be DEFAULT_HEARTBEAT + 1 seconds old when update is called
+        const oTimestamp = (await currentBlockTimestamp()) - DEFAULT_HEARTBEAT + 1;
+        await sbOracle.stubSetObservation(USDC, 0, totalBorrow, totalSupply, oTimestamp);
+
+        // Update the accumulator
+        const updateData = ethers.utils.defaultAbiCoder.encode(["address"], [USDC]);
+        await expect(accumulator.update(updateData)).to.be.revertedWith("AbstractOracle: RATE_TOO_OLD");
     });
 });

--- a/test/liquidity-accumulator/static-liquidity-accumulator.js
+++ b/test/liquidity-accumulator/static-liquidity-accumulator.js
@@ -244,17 +244,26 @@ describe("StaticLiquidityAccumulator#getLastAccumulation", function () {
 
     it("Returns a valid accumulation for the zero address", async function () {
         const accumulation = [BigNumber.from(0), BigNumber.from(0), await currentBlockTimestamp()];
-        expect(await accumulator.getLastAccumulation(AddressZero)).to.deep.eq(accumulation);
+        const [tokenAcc, quoteTokenAcc, timestamp] = await accumulator.getLastAccumulation(AddressZero);
+        expect(tokenAcc).to.equal(accumulation[0]);
+        expect(quoteTokenAcc).to.equal(accumulation[1]);
+        expect(timestamp).to.equal(accumulation[2]);
     });
 
     it("Returns a valid accumulation for the quote token", async function () {
         const accumulation = [BigNumber.from(0), BigNumber.from(0), await currentBlockTimestamp()];
-        expect(await accumulator.getLastAccumulation(USDC)).to.deep.eq(accumulation);
+        const [tokenAcc, quoteTokenAcc, timestamp] = await accumulator.getLastAccumulation(USDC);
+        expect(tokenAcc).to.equal(accumulation[0]);
+        expect(quoteTokenAcc).to.equal(accumulation[1]);
+        expect(timestamp).to.equal(accumulation[2]);
     });
 
     it("Returns a valid accumulation for a valid token", async function () {
         const accumulation = [BigNumber.from(0), BigNumber.from(0), await currentBlockTimestamp()];
-        expect(await accumulator.getLastAccumulation(GRT)).to.deep.eq(accumulation);
+        const [tokenAcc, quoteTokenAcc, timestamp] = await accumulator.getLastAccumulation(GRT);
+        expect(tokenAcc).to.equal(accumulation[0]);
+        expect(quoteTokenAcc).to.equal(accumulation[1]);
+        expect(timestamp).to.equal(accumulation[2]);
     });
 });
 
@@ -274,17 +283,26 @@ describe("StaticLiquidityAccumulator#getCurrentAccumulation", function () {
 
     it("Returns a valid accumulation for the zero address", async function () {
         const accumulation = [BigNumber.from(0), BigNumber.from(0), await currentBlockTimestamp()];
-        expect(await accumulator.getCurrentAccumulation(AddressZero)).to.deep.eq(accumulation);
+        const [tokenAcc, quoteTokenAcc, timestamp] = await accumulator.getCurrentAccumulation(AddressZero);
+        expect(tokenAcc).to.equal(accumulation[0]);
+        expect(quoteTokenAcc).to.equal(accumulation[1]);
+        expect(timestamp).to.equal(accumulation[2]);
     });
 
     it("Returns a valid accumulation for the quote token", async function () {
         const accumulation = [BigNumber.from(0), BigNumber.from(0), await currentBlockTimestamp()];
-        expect(await accumulator.getCurrentAccumulation(USDC)).to.deep.eq(accumulation);
+        const [tokenAcc, quoteTokenAcc, timestamp] = await accumulator.getCurrentAccumulation(USDC);
+        expect(tokenAcc).to.equal(accumulation[0]);
+        expect(quoteTokenAcc).to.equal(accumulation[1]);
+        expect(timestamp).to.equal(accumulation[2]);
     });
 
     it("Returns a valid accumulation for a valid token", async function () {
         const accumulation = [BigNumber.from(0), BigNumber.from(0), await currentBlockTimestamp()];
-        expect(await accumulator.getCurrentAccumulation(GRT)).to.deep.eq(accumulation);
+        const [tokenAcc, quoteTokenAcc, timestamp] = await accumulator.getCurrentAccumulation(GRT);
+        expect(tokenAcc).to.equal(accumulation[0]);
+        expect(quoteTokenAcc).to.equal(accumulation[1]);
+        expect(timestamp).to.equal(accumulation[2]);
     });
 });
 
@@ -296,9 +314,12 @@ describe("StaticLiquidityAccumulator#calculateLiquidity", function () {
             it(`Returns tokenLiquidity=${tokenLiquidity.toString()} and quoteTokenLiquidity=${quoteTokenLiquidity.toString()}`, async function () {
                 const liquidity = [tokenLiquidity, quoteTokenLiquidity];
                 const accumulator = await createDefaultAccumulator(USDC, tokenLiquidity, quoteTokenLiquidity);
-                expect(await accumulator.calculateLiquidity(ZERO_ACCUMULATION, ZERO_ACCUMULATION)).to.deep.eq(
-                    liquidity
+                const [calcTokenLiquidity, calcQuoteTokenLiquidity] = await accumulator.calculateLiquidity(
+                    ZERO_ACCUMULATION,
+                    ZERO_ACCUMULATION
                 );
+                expect(calcTokenLiquidity).to.equal(tokenLiquidity);
+                expect(calcQuoteTokenLiquidity).to.equal(quoteTokenLiquidity);
             });
         }
     }
@@ -315,7 +336,11 @@ describe("StaticLiquidityAccumulator#consultLiquidity(token)", function () {
                     it(`Returns tokenLiquidity=${tokenLiquidity.toString()} and quoteTokenLiquidity=${quoteTokenLiquidity.toString()} for the zero address`, async function () {
                         const liquidity = [tokenLiquidity, quoteTokenLiquidity];
                         const accumulator = await createDefaultAccumulator(token, tokenLiquidity, quoteTokenLiquidity);
-                        expect(await accumulator["consultLiquidity(address)"](token)).to.deep.eq(liquidity);
+                        const [consultTokenLiquidity, consultQuoteTokenLiquidity] = await accumulator[
+                            "consultLiquidity(address)"
+                        ](token);
+                        expect(consultTokenLiquidity).to.equal(tokenLiquidity);
+                        expect(consultQuoteTokenLiquidity).to.equal(quoteTokenLiquidity);
                     });
                 }
             }
@@ -334,7 +359,11 @@ describe("StaticLiquidityAccumulator#consultLiquidity(token, maxAge = 0)", funct
                     it(`Returns tokenLiquidity=${tokenLiquidity.toString()} and quoteTokenLiquidity=${quoteTokenLiquidity.toString()} for the zero address`, async function () {
                         const liquidity = [tokenLiquidity, quoteTokenLiquidity];
                         const accumulator = await createDefaultAccumulator(token, tokenLiquidity, quoteTokenLiquidity);
-                        expect(await accumulator["consultLiquidity(address,uint256)"](token, 0)).to.deep.eq(liquidity);
+                        const [consultTokenLiquidity, consultQuoteTokenLiquidity] = await accumulator[
+                            "consultLiquidity(address,uint256)"
+                        ](token, 0);
+                        expect(consultTokenLiquidity).to.equal(tokenLiquidity);
+                        expect(consultQuoteTokenLiquidity).to.equal(quoteTokenLiquidity);
                     });
                 }
             }
@@ -353,7 +382,11 @@ describe("StaticLiquidityAccumulator#consultLiquidity(token, maxAge = 1)", funct
                     it(`Returns tokenLiquidity=${tokenLiquidity.toString()} and quoteTokenLiquidity=${quoteTokenLiquidity.toString()} for the zero address`, async function () {
                         const liquidity = [tokenLiquidity, quoteTokenLiquidity];
                         const accumulator = await createDefaultAccumulator(token, tokenLiquidity, quoteTokenLiquidity);
-                        expect(await accumulator["consultLiquidity(address,uint256)"](token, 1)).to.deep.eq(liquidity);
+                        const [consultTokenLiquidity, consultQuoteTokenLiquidity] = await accumulator[
+                            "consultLiquidity(address,uint256)"
+                        ](token, 1);
+                        expect(consultTokenLiquidity).to.equal(tokenLiquidity);
+                        expect(consultQuoteTokenLiquidity).to.equal(quoteTokenLiquidity);
                     });
                 }
             }
@@ -377,7 +410,11 @@ describe("StaticLiquidityAccumulator#fetchLiquidity", function () {
                             tokenLiquidity,
                             quoteTokenLiquidity
                         );
-                        expect(await accumulator.stubFetchLiquidity(updateData)).to.deep.eq(liquidity);
+                        const [fetchTokenLiquidity, fetchQuoteTokenLiquidity] = await accumulator.stubFetchLiquidity(
+                            updateData
+                        );
+                        expect(fetchTokenLiquidity).to.equal(tokenLiquidity);
+                        expect(fetchQuoteTokenLiquidity).to.equal(quoteTokenLiquidity);
                     });
                 }
             }

--- a/test/liquidity-accumulator/supply-borrow-accumulator.js
+++ b/test/liquidity-accumulator/supply-borrow-accumulator.js
@@ -587,9 +587,9 @@ function createDescribeCompoundV2FetchLiquidityTests(typicalSupplyCalculation) {
     };
 }
 
-function createDescribeSpecificVenusIsolatedFetchLiquidityTests() {
-    return function describeVenusIsolatedFetchLiquidityTests(contractName, deployContracts) {
-        describe("Venus isolated special cases", function () {
+function createDescribeSpecificVenusFetchLiquidityTests() {
+    return function describeVenusFetchLiquidityTests(contractName, deployContracts) {
+        describe("Venus special cases", function () {
             var poolStub;
             var accumulator;
             var decimals;
@@ -657,13 +657,13 @@ function createDescribeIonicFetchLiquidityTests() {
     return createDescribeCompoundV2FetchLiquidityTests(false);
 }
 
-function createDescribeVenusIsolatedFetchLiquidityTests() {
+function createDescribeVenusFetchLiquidityTests() {
     const stdDescribe = createDescribeCompoundV2FetchLiquidityTests(true);
-    const venusIsolatedDescribe = createDescribeSpecificVenusIsolatedFetchLiquidityTests();
+    const venusDescribe = createDescribeSpecificVenusFetchLiquidityTests();
 
     return (contractName, deployContracts) => {
         stdDescribe(contractName, deployContracts);
-        venusIsolatedDescribe(contractName, deployContracts);
+        venusDescribe(contractName, deployContracts);
     };
 }
 
@@ -974,10 +974,10 @@ async function deployIonicContracts(baseToken, decimals) {
     };
 }
 
-async function deployVenusIsolatedContracts(baseToken, decimals) {
+async function deployVenusContracts(baseToken, decimals) {
     const poolStubFactory = await ethers.getContractFactory("IonicStub");
     const averagingStrategyFactory = await ethers.getContractFactory("ArithmeticAveraging");
-    const accumulatorFactory = await ethers.getContractFactory("VenusIsolatedSBAccumulatorStub");
+    const accumulatorFactory = await ethers.getContractFactory("VenusSBAccumulatorStub");
     const cTokenFactory = await ethers.getContractFactory("IonicCTokenStub");
 
     const poolStub = await poolStubFactory.deploy();
@@ -1188,12 +1188,12 @@ describeSBAccumulatorTests(
     createDescribeCompoundV2FetchLiquidityTests(true)
 );
 describeSBAccumulatorTests(
-    "VenusIsolatedSBAccumulator",
-    deployVenusIsolatedContracts,
+    "VenusSBAccumulator",
+    deployVenusContracts,
     ionicSetSupply,
     ionicSetBorrow,
     [_WETH, _USDC],
     true,
     false,
-    createDescribeVenusIsolatedFetchLiquidityTests()
+    createDescribeVenusFetchLiquidityTests()
 );

--- a/test/oracles/current-aggregator-oracle.js
+++ b/test/oracles/current-aggregator-oracle.js
@@ -2534,13 +2534,13 @@ describe("CurrentAggregatorOracle#update w/ 1 underlying oracle", function () {
 
         const updateTime = await blockTimestamp(receipt.blockNumber);
 
-        // Expect that the new observation is what we expect
-        expect(await oracle.getLatestObservation(token)).to.deep.equal([
-            newPrice,
-            tokenLiquidity,
-            quoteTokenLiquidity,
-            updateTime,
-        ]);
+        const [observedPrice, observedTokenLiquidity, observedQuoteTokenLiquidity, observedUpdateTime] =
+            await oracle.getLatestObservation(token);
+
+        expect(observedPrice).to.equal(newPrice);
+        expect(observedTokenLiquidity).to.equal(tokenLiquidity);
+        expect(observedQuoteTokenLiquidity).to.equal(quoteTokenLiquidity);
+        expect(observedUpdateTime).to.equal(updateTime);
     });
 
     it("Should update when the price moves above the update threshold (with the price moving down)", async () => {
@@ -2575,13 +2575,13 @@ describe("CurrentAggregatorOracle#update w/ 1 underlying oracle", function () {
 
         const updateTime = await blockTimestamp(receipt.blockNumber);
 
-        // Expect that the new observation is what we expect
-        expect(await oracle.getLatestObservation(token)).to.deep.equal([
-            newPrice,
-            tokenLiquidity,
-            quoteTokenLiquidity,
-            updateTime,
-        ]);
+        const [observedPrice, observedTokenLiquidity, observedQuoteTokenLiquidity, observedUpdateTime] =
+            await oracle.getLatestObservation(token);
+
+        expect(observedPrice).to.equal(newPrice);
+        expect(observedTokenLiquidity).to.equal(tokenLiquidity);
+        expect(observedQuoteTokenLiquidity).to.equal(quoteTokenLiquidity);
+        expect(observedUpdateTime).to.equal(updateTime);
     });
 
     it("Should update when the price doesn't move at all, but a heartbeat is needed", async () => {
@@ -2609,13 +2609,13 @@ describe("CurrentAggregatorOracle#update w/ 1 underlying oracle", function () {
 
         const updateTime = await blockTimestamp(receipt.blockNumber);
 
-        // Expect that the new observation is what we expect
-        expect(await oracle.getLatestObservation(token)).to.deep.equal([
-            price,
-            tokenLiquidity,
-            quoteTokenLiquidity,
-            updateTime,
-        ]);
+        const [observedPrice, observedTokenLiquidity, observedQuoteTokenLiquidity, observedUpdateTime] =
+            await oracle.getLatestObservation(token);
+
+        expect(observedPrice).to.equal(price);
+        expect(observedTokenLiquidity).to.equal(tokenLiquidity);
+        expect(observedQuoteTokenLiquidity).to.equal(quoteTokenLiquidity);
+        expect(observedUpdateTime).to.equal(updateTime);
     });
 
     it("Shouldn't update when the price moves above the update threshold (with the price moving up), but the minimum delay hasn't been reached", async () => {

--- a/test/oracles/otf-aggregator-oracle.js
+++ b/test/oracles/otf-aggregator-oracle.js
@@ -1,0 +1,2153 @@
+const { BigNumber } = require("ethers");
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const AddressZero = ethers.constants.AddressZero;
+const MaxUint256 = ethers.constants.MaxUint256;
+
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const GRT = "0xc944E90C64B2c07662A292be6244BDf05Cda44a7";
+const BAT = "0x0D8775F648430679A709E98d2b0Cb6250d2887EF";
+
+const DEFAULT_UPDATE_THRESHOLD = 2000000; // 2% change
+const DEFAULT_UPDATE_DELAY = 5; // At least 5 seconds between every update
+const DEFAULT_HEARTBEAT = 60 * 60; // At most (optimistically) 1 hour between every update
+
+const DEFAULT_MIN_FRESHNESS = 60 * 60; // 1 hour
+const DEFAULT_MIN_RESPONSES = 1; // At least 1 response from the underlying oracles
+
+const MINIMUM_TOKEN_LIQUIDITY_VALUE = BigNumber.from(0);
+const MINIMUM_QUOTE_TOKEN_LIQUIDITY = BigNumber.from(0);
+const MINIMUM_LIQUIDITY_RATIO = 1000; // 1:10 value(token):value(quoteToken)
+const MAXIMUM_LIQUIDITY_RATIO = 100000; // 10:1 value(token):value(quoteToken)
+
+const AGGREGATION_TIMESTAMP_STRATEGY_LATESTOBSERVATION = 2;
+
+const DEFAULT_AGGREGATION_TIMESTAMP_STRATEGY = AGGREGATION_TIMESTAMP_STRATEGY_LATESTOBSERVATION;
+
+const LOWEST_ACCEPTABLE_PRICE = BigNumber.from(2);
+const LOWEST_ACCEPTABLE_LIQUIDITY = BigNumber.from(2);
+
+const DEFAULT_AGGREGATOR_CONSTRUCTOR_PARAMS = {
+    aggregationStrategy: null,
+    validationStrategy: null,
+    quoteTokenName: "USD Coin",
+    quoteTokenAddress: USDC,
+    quoteTokenSymbol: "USDC",
+    quoteTokenDecimals: 6,
+    liquidityDecimals: 0,
+    oracles: [],
+    tokenSpecificOracles: [],
+    updateThreshold: DEFAULT_UPDATE_THRESHOLD,
+    updateDelay: DEFAULT_UPDATE_DELAY,
+    heartbeat: DEFAULT_HEARTBEAT,
+};
+
+async function currentBlockTimestamp() {
+    const currentBlockNumber = await ethers.provider.getBlockNumber();
+
+    return await blockTimestamp(currentBlockNumber);
+}
+
+async function blockTimestamp(blockNum) {
+    return (await ethers.provider.getBlock(blockNum)).timestamp;
+}
+
+function harmonicMean(values, weights) {
+    var numerator = BigNumber.from(0);
+    var denominator = BigNumber.from(0);
+
+    for (var i = 0; i < values.length; ++i) {
+        numerator = numerator.add(weights[i]);
+        denominator = denominator.add(weights[i].div(values[i]));
+    }
+
+    return numerator.div(denominator);
+}
+
+async function constructDefaultAggregator(
+    factory,
+    constructorOverrides,
+    minimumTokenLiquidityValue = MINIMUM_TOKEN_LIQUIDITY_VALUE,
+    minimumQuoteTokenLiquidity = MINIMUM_QUOTE_TOKEN_LIQUIDITY,
+    minimumLiquidityRatio = MINIMUM_LIQUIDITY_RATIO,
+    maximumLiquidityRatio = MAXIMUM_LIQUIDITY_RATIO
+) {
+    var params = {
+        ...DEFAULT_AGGREGATOR_CONSTRUCTOR_PARAMS,
+        ...constructorOverrides,
+    };
+
+    if (params.aggregationStrategy === null) {
+        const aggregationStrategyFactory = await ethers.getContractFactory("DefaultAggregator2");
+        const aggregationStrategy = await aggregationStrategyFactory.deploy(DEFAULT_AGGREGATION_TIMESTAMP_STRATEGY);
+        await aggregationStrategy.deployed();
+
+        params = {
+            ...params,
+            aggregationStrategy: aggregationStrategy.address,
+        };
+    }
+
+    if (params.validationStrategy === null) {
+        const validationStrategyFactory = await ethers.getContractFactory("DefaultValidationStub");
+
+        const validationStrategy = await validationStrategyFactory.deploy(
+            params.quoteTokenDecimals,
+            minimumTokenLiquidityValue,
+            minimumQuoteTokenLiquidity,
+            minimumLiquidityRatio,
+            maximumLiquidityRatio
+        );
+        await validationStrategy.deployed();
+
+        params = {
+            ...params,
+            validationStrategy: validationStrategy.address,
+        };
+    }
+
+    const minimumFreshness = params.minimumFreshness || DEFAULT_MIN_FRESHNESS;
+    const minimumResponses = params.minimumResponses || DEFAULT_MIN_RESPONSES;
+
+    delete params.minimumFreshness;
+    delete params.minimumResponses;
+
+    return await factory.deploy(params, minimumFreshness, minimumResponses);
+}
+
+describe("OtfAggregatorOracle#constructor", async function () {
+    var underlyingOracleFactory;
+    var oracleFactory;
+    var aggregationStrategyFactory;
+
+    beforeEach(async () => {
+        oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+        underlyingOracleFactory = await ethers.getContractFactory("MockOracle");
+        aggregationStrategyFactory = await ethers.getContractFactory("DefaultAggregator");
+    });
+
+    it("Should deploy correctly with valid arguments", async function () {
+        const oracle1 = await underlyingOracleFactory.deploy(USDC);
+        await oracle1.deployed();
+
+        const oracle2 = await underlyingOracleFactory.deploy(USDC);
+        await oracle2.deployed();
+
+        const aggregationStrategy = await aggregationStrategyFactory.deploy();
+        await aggregationStrategy.deployed();
+
+        const grtOracle = {
+            token: GRT,
+            oracle: oracle2.address,
+        };
+
+        const validationStrategyAddress = AddressZero;
+        const quoteTokenName = "USD Coin";
+        const quoteTokenAddress = USDC;
+        const quoteTokenSymbol = "USDC";
+        const quoteTokenDecimals = 6;
+        const liquidityDecimals = 4;
+        const oracles = [oracle1.address];
+        const tokenSpecificOracles = [grtOracle];
+        const minimumFreshness = DEFAULT_MIN_FRESHNESS;
+        const minimumResponses = DEFAULT_MIN_RESPONSES;
+
+        const oracle = await oracleFactory.deploy(
+            {
+                aggregationStrategy: aggregationStrategy.address,
+                validationStrategy: validationStrategyAddress,
+                quoteTokenName,
+                quoteTokenAddress,
+                quoteTokenSymbol,
+                quoteTokenDecimals,
+                liquidityDecimals,
+                oracles,
+                tokenSpecificOracles,
+            },
+            minimumFreshness,
+            minimumResponses
+        );
+
+        const generalOracles = [
+            [oracle1.address, await oracle1.quoteTokenDecimals(), await oracle1.liquidityDecimals()],
+        ];
+
+        const grtOracles = [
+            ...generalOracles,
+            [oracle2.address, await oracle2.quoteTokenDecimals(), await oracle2.liquidityDecimals()],
+        ];
+
+        expect(await oracle.aggregationStrategy(BAT)).to.equal(aggregationStrategy.address);
+        expect(await oracle.validationStrategy(BAT)).to.equal(validationStrategyAddress);
+        expect(await oracle.quoteTokenName()).to.equal(quoteTokenName);
+        expect(await oracle.quoteTokenAddress()).to.equal(quoteTokenAddress);
+        expect(await oracle.quoteTokenSymbol()).to.equal(quoteTokenSymbol);
+        expect(await oracle.quoteTokenDecimals()).to.equal(quoteTokenDecimals);
+        expect(await oracle.liquidityDecimals()).to.equal(liquidityDecimals);
+        expect(await oracle.getOracles(BAT)).to.eql(generalOracles); // eql = deep equality
+        expect(await oracle.maximumResponseAge(BAT)).to.equal(minimumFreshness);
+        expect(await oracle.minimumResponses(BAT)).to.equal(minimumResponses);
+
+        expect(await oracle.getOracles(grtOracle.token)).to.eql(grtOracles);
+    });
+
+    it("Should deploy correctly with alternative valid arguments", async function () {
+        const oracle1 = await underlyingOracleFactory.deploy(USDC);
+        await oracle1.deployed();
+
+        const oracle2 = await underlyingOracleFactory.deploy(USDC);
+        await oracle2.deployed();
+
+        const aggregationStrategy = await aggregationStrategyFactory.deploy();
+        await aggregationStrategy.deployed();
+
+        const validationStrategyAddress = AddressZero;
+        const quoteTokenName = "USD Coin";
+        const quoteTokenAddress = USDC;
+        const quoteTokenSymbol = "USDC";
+        const quoteTokenDecimals = 0;
+        const liquidityDecimals = 0;
+        const oracles = [oracle1.address, oracle2.address];
+        const tokenSpecificOracles = [];
+        const minimumFreshness = DEFAULT_MIN_FRESHNESS * 2;
+        const minimumResponses = DEFAULT_MIN_RESPONSES + 1;
+
+        const oracle = await oracleFactory.deploy(
+            {
+                aggregationStrategy: aggregationStrategy.address,
+                validationStrategy: validationStrategyAddress,
+                quoteTokenName,
+                quoteTokenAddress,
+                quoteTokenSymbol,
+                quoteTokenDecimals,
+                liquidityDecimals,
+                oracles,
+                tokenSpecificOracles,
+            },
+            minimumFreshness,
+            minimumResponses
+        );
+
+        const generalOracles = [
+            [oracle1.address, await oracle1.quoteTokenDecimals(), await oracle1.liquidityDecimals()],
+            [oracle2.address, await oracle2.quoteTokenDecimals(), await oracle2.liquidityDecimals()],
+        ];
+
+        expect(await oracle.aggregationStrategy(BAT)).to.equal(aggregationStrategy.address);
+        expect(await oracle.validationStrategy(BAT)).to.equal(validationStrategyAddress);
+        expect(await oracle.quoteTokenName()).to.equal(quoteTokenName);
+        expect(await oracle.quoteTokenAddress()).to.equal(quoteTokenAddress);
+        expect(await oracle.quoteTokenSymbol()).to.equal(quoteTokenSymbol);
+        expect(await oracle.quoteTokenDecimals()).to.equal(quoteTokenDecimals);
+        expect(await oracle.liquidityDecimals()).to.equal(liquidityDecimals);
+        expect(await oracle.getOracles(BAT)).to.eql(generalOracles); // eql = deep equality
+        expect(await oracle.maximumResponseAge(BAT)).to.equal(minimumFreshness);
+        expect(await oracle.minimumResponses(BAT)).to.equal(minimumResponses);
+    });
+
+    it("Should not revert if no underlying oracles are provided", async () => {
+        const aggregationStrategy = await aggregationStrategyFactory.deploy();
+        await aggregationStrategy.deployed();
+
+        const validationStrategyAddress = AddressZero;
+
+        await expect(
+            oracleFactory.deploy(
+                {
+                    aggregationStrategy: aggregationStrategy.address,
+                    validationStrategy: validationStrategyAddress,
+                    quoteTokenName: "NAME",
+                    quoteTokenAddress: USDC,
+                    quoteTokenSymbol: "NIL",
+                    quoteTokenDecimals: 18,
+                    liquidityDecimals: 0,
+                    oracles: [],
+                    tokenSpecificOracles: [],
+                },
+                DEFAULT_MIN_FRESHNESS,
+                DEFAULT_MIN_RESPONSES
+            )
+        ).to.not.be.reverted;
+    });
+
+    it("Should revert if duplicate general oracles are provided", async () => {
+        const aggregationStrategy = await aggregationStrategyFactory.deploy();
+        await aggregationStrategy.deployed();
+
+        const validationStrategyAddress = AddressZero;
+
+        const oracle1 = await underlyingOracleFactory.deploy(USDC);
+        await oracle1.deployed();
+
+        await expect(
+            oracleFactory.deploy(
+                {
+                    aggregationStrategy: aggregationStrategy.address,
+                    validationStrategy: validationStrategyAddress,
+                    quoteTokenName: "NAME",
+                    quoteTokenAddress: USDC,
+                    quoteTokenSymbol: "NIL",
+                    quoteTokenDecimals: 18,
+                    liquidityDecimals: 0,
+                    oracles: [oracle1.address, oracle1.address],
+                    tokenSpecificOracles: [],
+                },
+                DEFAULT_MIN_FRESHNESS,
+                DEFAULT_MIN_RESPONSES
+            )
+        ).to.be.revertedWith("AbstractAggregatorOracle: DUPLICATE_ORACLE");
+    });
+
+    it("Should revert if duplicate token specific oracles are provided", async () => {
+        const aggregationStrategy = await aggregationStrategyFactory.deploy();
+        await aggregationStrategy.deployed();
+
+        const validationStrategyAddress = AddressZero;
+
+        const oracle1 = await underlyingOracleFactory.deploy(USDC);
+        await oracle1.deployed();
+
+        const oracle1Config = {
+            token: GRT,
+            oracle: oracle1.address,
+        };
+
+        await expect(
+            oracleFactory.deploy(
+                {
+                    aggregationStrategy: aggregationStrategy.address,
+                    validationStrategy: validationStrategyAddress,
+                    quoteTokenName: "NAME",
+                    quoteTokenAddress: USDC,
+                    quoteTokenSymbol: "NIL",
+                    quoteTokenDecimals: 18,
+                    liquidityDecimals: 0,
+                    oracles: [],
+                    tokenSpecificOracles: [oracle1Config, oracle1Config],
+                },
+                DEFAULT_MIN_FRESHNESS,
+                DEFAULT_MIN_RESPONSES
+            )
+        ).to.be.revertedWith("AbstractAggregatorOracle: DUPLICATE_ORACLE");
+    });
+
+    it("Should revert if duplicate general / token specific oracles are provided", async () => {
+        const aggregationStrategy = await aggregationStrategyFactory.deploy();
+        await aggregationStrategy.deployed();
+
+        const validationStrategyAddress = AddressZero;
+
+        const oracle1 = await underlyingOracleFactory.deploy(USDC);
+        await oracle1.deployed();
+
+        const oracle1Config = {
+            token: GRT,
+            oracle: oracle1.address,
+        };
+
+        await expect(
+            oracleFactory.deploy(
+                {
+                    aggregationStrategy: aggregationStrategy.address,
+                    validationStrategy: validationStrategyAddress,
+                    quoteTokenName: "NAME",
+                    quoteTokenAddress: USDC,
+                    quoteTokenSymbol: "NIL",
+                    quoteTokenDecimals: 18,
+                    liquidityDecimals: 0,
+                    oracles: [oracle1.address],
+                    tokenSpecificOracles: [oracle1Config],
+                },
+                DEFAULT_MIN_FRESHNESS,
+                DEFAULT_MIN_RESPONSES
+            )
+        ).to.be.revertedWith("AbstractAggregatorOracle: DUPLICATE_ORACLE");
+    });
+
+    it("Should revert if the quote token decimals is different from that of the validation strategy", async function () {
+        const aggregationStrategy = await aggregationStrategyFactory.deploy();
+        await aggregationStrategy.deployed();
+
+        const validationStrategyFactory = await ethers.getContractFactory("DefaultValidation");
+        const validationStrategy = await validationStrategyFactory.deploy(21, 0, 0, 0, 0);
+        await validationStrategy.deployed();
+
+        const oracle1 = await underlyingOracleFactory.deploy(USDC);
+        await oracle1.deployed();
+
+        await expect(
+            oracleFactory.deploy(
+                {
+                    aggregationStrategy: aggregationStrategy.address,
+                    validationStrategy: validationStrategy.address,
+                    quoteTokenName: "NAME",
+                    quoteTokenAddress: USDC,
+                    quoteTokenSymbol: "NIL",
+                    quoteTokenDecimals: 17,
+                    liquidityDecimals: 0,
+                    oracles: [oracle1.address],
+                    tokenSpecificOracles: [],
+                },
+                DEFAULT_MIN_FRESHNESS,
+                DEFAULT_MIN_RESPONSES
+            )
+        ).to.be.revertedWith("AbstractAggregatorOracle: QUOTE_TOKEN_DECIMALS_MISMATCH");
+    });
+
+    it("Should revert if the minimum freshness is zero", async function () {
+        const aggregationStrategy = await aggregationStrategyFactory.deploy();
+        await aggregationStrategy.deployed();
+
+        const validationStrategyAddress = AddressZero;
+        const oracle1 = await underlyingOracleFactory.deploy(USDC);
+
+        await oracle1.deployed();
+
+        await expect(
+            oracleFactory.deploy(
+                {
+                    aggregationStrategy: aggregationStrategy.address,
+                    validationStrategy: validationStrategyAddress,
+                    quoteTokenName: "NAME",
+                    quoteTokenAddress: USDC,
+                    quoteTokenSymbol: "NIL",
+                    quoteTokenDecimals: 18,
+                    liquidityDecimals: 0,
+                    oracles: [oracle1.address],
+                    tokenSpecificOracles: [],
+                },
+                0, // minimum freshness
+                DEFAULT_MIN_RESPONSES
+            )
+        ).to.be.revertedWith("InvalidMinimumFreshness");
+    });
+
+    it("Should revert if the minimum responses is zero", async function () {
+        const aggregationStrategy = await aggregationStrategyFactory.deploy();
+        await aggregationStrategy.deployed();
+        const validationStrategyAddress = AddressZero;
+        const oracle1 = await underlyingOracleFactory.deploy(USDC);
+        await oracle1.deployed();
+        await expect(
+            oracleFactory.deploy(
+                {
+                    aggregationStrategy: aggregationStrategy.address,
+                    validationStrategy: validationStrategyAddress,
+                    quoteTokenName: "NAME",
+                    quoteTokenAddress: USDC,
+                    quoteTokenSymbol: "NIL",
+                    quoteTokenDecimals: 18,
+                    liquidityDecimals: 0,
+                    oracles: [oracle1.address],
+                    tokenSpecificOracles: [],
+                },
+                DEFAULT_MIN_FRESHNESS,
+                0 // minimum responses
+            )
+        ).to.be.revertedWith("InvalidMinimumResponses");
+    });
+});
+
+describe("OtfAggregatorOracle#needsUpdate", function () {
+    var oracle;
+
+    beforeEach(async function () {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+        const underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        const constructorOverrides = {
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+        // Time increases by 1 second with each block mined
+        await hre.timeAndMine.setTimeIncrease(1);
+
+        // Push an underlying observation for GRT, so that aggregation works
+        const updateTime = await currentBlockTimestamp();
+        await underlyingOracle.stubSetObservation(
+            GRT,
+            LOWEST_ACCEPTABLE_PRICE,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            updateTime
+        );
+    });
+
+    it("Should return false", async function () {
+        expect(await oracle.needsUpdate(ethers.utils.hexZeroPad(GRT, 32))).to.equal(false);
+    });
+});
+
+describe("OtfAggregatorOracle#canUpdate", function () {
+    var oracle;
+
+    beforeEach(async function () {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+        const validationStrategyFactory = await ethers.getContractFactory("ValidationStub");
+
+        const validationStrategy = await validationStrategyFactory.deploy();
+        await validationStrategy.deployed();
+        await validationStrategy.stubSetQuoteTokenDecimals(DEFAULT_AGGREGATOR_CONSTRUCTOR_PARAMS.quoteTokenDecimals);
+
+        underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        const constructorOverrides = {
+            validationStrategy: validationStrategy.address,
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+        // Time increases by 1 second with each block mined
+        await hre.timeAndMine.setTimeIncrease(1);
+
+        // Push an underlying observation for GRT, so that aggregation works
+        updateTime = await currentBlockTimestamp();
+        await underlyingOracle.stubSetObservation(
+            GRT,
+            LOWEST_ACCEPTABLE_PRICE,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            updateTime
+        );
+    });
+
+    it("Should return false", async function () {
+        expect(await oracle.canUpdate(ethers.utils.hexZeroPad(GRT, 32))).to.equal(false);
+    });
+});
+
+describe("OtfAggregatorOracle#consultPrice(token)", function () {
+    var oracle;
+    var underlyingOracle;
+
+    beforeEach(async () => {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+        underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        const quoteTokenDecimals = await underlyingOracle.quoteTokenDecimals();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            quoteTokenDecimals: quoteTokenDecimals,
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+    });
+
+    it("Should revert when there's no observation", async () => {
+        await expect(oracle["consultPrice(address)"](GRT)).to.be.revertedWith(
+            "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+        );
+    });
+
+    it("Should revert when the underlying observation is expired", async () => {
+        await hre.timeAndMine.setTimeIncrease(1);
+
+        // On the bounds of the freshness (not expired yet)
+        const updateTime = (await currentBlockTimestamp()) - DEFAULT_MIN_FRESHNESS;
+
+        // This will cause time to increase by 1 second, thus making the observation expired
+        await underlyingOracle.stubSetObservation(
+            GRT,
+            LOWEST_ACCEPTABLE_PRICE,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            updateTime
+        );
+
+        await expect(oracle["consultPrice(address)"](GRT)).to.be.revertedWith(
+            "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+        );
+    });
+
+    it(`Should get the set price (=${LOWEST_ACCEPTABLE_PRICE})`, async () => {
+        const price = LOWEST_ACCEPTABLE_PRICE;
+
+        const updateTime = (await currentBlockTimestamp()) - 10;
+
+        await underlyingOracle.stubSetObservation(
+            GRT,
+            price,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            updateTime
+        );
+
+        expect(await oracle["consultPrice(address)"](GRT)).to.equal(price);
+    });
+
+    it("Should get the set price (=1e18)", async () => {
+        const price = BigNumber.from(10).pow(18);
+
+        const updateTime = (await currentBlockTimestamp()) - 10;
+
+        await underlyingOracle.stubSetObservation(
+            GRT,
+            price,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            updateTime
+        );
+
+        expect(await oracle["consultPrice(address)"](GRT)).to.equal(price);
+    });
+
+    it("Should return fixed values when token == quoteToken", async function () {
+        const price = await oracle["consultPrice(address)"](await oracle.quoteTokenAddress());
+
+        const expectedPrice = ethers.utils.parseUnits("1.0", await oracle.quoteTokenDecimals());
+
+        expect(price).to.equal(expectedPrice);
+    });
+});
+
+describe("OtfAggregatorOracle#consultPrice(token, maxAge = 0)", function () {
+    var underlyingOracle;
+    var oracle;
+
+    beforeEach(async () => {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+        underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        const quoteTokenDecimals = await underlyingOracle.quoteTokenDecimals();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            quoteTokenDecimals: quoteTokenDecimals,
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+    });
+
+    it(`Should get the set price (=${LOWEST_ACCEPTABLE_PRICE})`, async () => {
+        const price = LOWEST_ACCEPTABLE_PRICE;
+        const tokenLiqudity = BigNumber.from(2);
+        const quoteTokenLiquidity = BigNumber.from(3);
+
+        await underlyingOracle.stubSetInstantRates(GRT, price, tokenLiqudity, quoteTokenLiquidity);
+
+        expect(await oracle["consultPrice(address,uint256)"](GRT, 0)).to.equal(price);
+    });
+
+    it("Should get the set price (=1e18)", async () => {
+        const price = BigNumber.from(10).pow(18);
+
+        await underlyingOracle.stubSetInstantRates(
+            GRT,
+            price,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            LOWEST_ACCEPTABLE_LIQUIDITY
+        );
+
+        expect(await oracle["consultPrice(address,uint256)"](GRT, 0)).to.equal(price);
+    });
+
+    it("Should return fixed values when token == quoteToken", async function () {
+        const price = await oracle["consultPrice(address,uint256)"](await oracle.quoteTokenAddress(), 0);
+
+        const expectedPrice = ethers.utils.parseUnits("1.0", await oracle.quoteTokenDecimals());
+
+        expect(price).to.equal(expectedPrice);
+    });
+});
+
+describe("OtfAggregatorOracle#consultPrice(token, maxAge)", function () {
+    const MAX_AGE = 60;
+
+    var oracle;
+    var underlyingOracle;
+
+    beforeEach(async () => {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+        underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        const quoteTokenDecimals = await underlyingOracle.quoteTokenDecimals();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            quoteTokenDecimals: quoteTokenDecimals,
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+        // Time increases by 1 second with each block mined
+        await hre.timeAndMine.setTimeIncrease(1);
+    });
+
+    it("Should revert when there's no observation", async () => {
+        await expect(oracle["consultPrice(address,uint256)"](GRT, MAX_AGE)).to.be.revertedWith(
+            "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+        );
+    });
+
+    it("Should revert when the rate is expired (deltaTime > maxAge)", async () => {
+        const observationTime = await currentBlockTimestamp();
+
+        await underlyingOracle.stubSetObservation(GRT, 1, 1, 1, observationTime);
+
+        const time = observationTime + MAX_AGE + 1;
+
+        await hre.timeAndMine.setTime(time);
+
+        expect(await currentBlockTimestamp()).to.equal(time);
+        await expect(oracle["consultPrice(address,uint256)"](GRT, MAX_AGE)).to.be.revertedWith(
+            "AbstractOracle: RATE_TOO_OLD"
+        );
+    });
+
+    it("Shouldn't revert when the rate is not expired (deltaTime == maxAge)", async () => {
+        const observationTime = await currentBlockTimestamp();
+
+        await underlyingOracle.stubSetObservation(GRT, 1, 1, 1, observationTime);
+
+        const time = observationTime + MAX_AGE;
+
+        await hre.timeAndMine.setTime(time);
+
+        await oracle["consultPrice(address)"](GRT);
+
+        expect(await currentBlockTimestamp()).to.equal(time);
+        await expect(oracle["consultPrice(address,uint256)"](GRT, MAX_AGE)).to.not.be.reverted;
+    });
+
+    it("Shouldn't revert when the rate is not expired (deltaTime < maxAge)", async () => {
+        const observationTime = await currentBlockTimestamp();
+
+        await underlyingOracle.stubSetObservation(GRT, 1, 1, 1, observationTime);
+
+        const time = observationTime + MAX_AGE - 1;
+
+        await hre.timeAndMine.setTime(time);
+
+        expect(await currentBlockTimestamp()).to.equal(time);
+        await expect(oracle["consultPrice(address,uint256)"](GRT, MAX_AGE)).to.not.be.reverted;
+    });
+
+    it("Shouldn't revert when the rate is not expired (deltaTime == 0)", async () => {
+        const observationTime = (await currentBlockTimestamp()) + 10;
+
+        await underlyingOracle.stubSetObservation(GRT, 1, 1, 1, observationTime);
+
+        const time = observationTime;
+
+        await hre.timeAndMine.setTime(time);
+
+        expect(await currentBlockTimestamp()).to.equal(time);
+        await expect(oracle["consultPrice(address,uint256)"](GRT, MAX_AGE)).to.not.be.reverted;
+    });
+
+    it(`Should get the set price (=${LOWEST_ACCEPTABLE_PRICE})`, async () => {
+        const observationTime = await currentBlockTimestamp();
+        const price = LOWEST_ACCEPTABLE_PRICE;
+
+        await underlyingOracle.stubSetObservation(
+            GRT,
+            price,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            observationTime
+        );
+
+        expect(await oracle["consultPrice(address,uint256)"](GRT, MAX_AGE)).to.equal(price);
+    });
+
+    it("Should get the set price (=1e18)", async () => {
+        const observationTime = await currentBlockTimestamp();
+        const price = BigNumber.from(10).pow(18);
+
+        await underlyingOracle.stubSetObservation(
+            GRT,
+            price,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            LOWEST_ACCEPTABLE_LIQUIDITY,
+            observationTime
+        );
+
+        expect(await oracle["consultPrice(address,uint256)"](GRT, MAX_AGE)).to.equal(price);
+    });
+
+    it("Should return fixed values when token == quoteToken", async function () {
+        const price = await oracle["consultPrice(address,uint256)"](await oracle.quoteTokenAddress(), MAX_AGE);
+
+        const expectedPrice = ethers.utils.parseUnits("1.0", await oracle.quoteTokenDecimals());
+
+        expect(price).to.equal(expectedPrice);
+    });
+});
+
+describe("OtfAggregatorOracle#consultLiquidity(token)", function () {
+    var oracle;
+    var underlyingOracle;
+
+    const tests = [
+        {
+            args: {
+                price: BigNumber.from(1),
+                tokenLiquidity: BigNumber.from(1),
+                quoteTokenLiquidity: BigNumber.from(1),
+            },
+        },
+        {
+            args: {
+                price: BigNumber.from(1),
+                tokenLiquidity: BigNumber.from(1),
+                quoteTokenLiquidity: BigNumber.from("1000000000000000000"),
+            },
+        },
+        {
+            args: {
+                price: BigNumber.from(1),
+                tokenLiquidity: BigNumber.from("1000000000000000000"),
+                quoteTokenLiquidity: BigNumber.from(1),
+            },
+        },
+        {
+            args: {
+                price: BigNumber.from(1),
+                tokenLiquidity: BigNumber.from("1000000000000000000"),
+                quoteTokenLiquidity: BigNumber.from("1000000000000000000"),
+            },
+        },
+    ];
+
+    beforeEach(async () => {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+        underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        const quoteTokenDecimals = await underlyingOracle.quoteTokenDecimals();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            quoteTokenDecimals: quoteTokenDecimals,
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+    });
+
+    it("Should revert when there's no observation", async () => {
+        await expect(oracle["consultLiquidity(address)"](GRT)).to.be.revertedWith(
+            "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+        );
+    });
+
+    it("Should return fixed values when token == quoteToken", async function () {
+        const [tokenLiqudity, quoteTokenLiquidity] = await oracle["consultLiquidity(address)"](
+            await oracle.quoteTokenAddress()
+        );
+
+        expect(tokenLiqudity).to.equal(0);
+        expect(quoteTokenLiquidity).to.equal(0);
+    });
+
+    tests.forEach(({ args }) => {
+        it(`Should get the set token liquidity (=${args["tokenLiquidity"]}) and quote token liquidity (=${args["quoteTokenLiquidity"]})`, async () => {
+            const _price = args["price"];
+            const _tokenLiqudity = args["tokenLiquidity"];
+            const _quoteTokenLiquidity = args["quoteTokenLiquidity"];
+
+            const observationTime = await currentBlockTimestamp();
+
+            await underlyingOracle.stubSetObservation(
+                GRT,
+                _price,
+                _tokenLiqudity,
+                _quoteTokenLiquidity,
+                observationTime
+            );
+
+            const [tokenLiqudity, quoteTokenLiquidity] = await oracle["consultLiquidity(address)"](GRT);
+
+            expect(tokenLiqudity).to.equal(_tokenLiqudity);
+            expect(quoteTokenLiquidity).to.equal(_quoteTokenLiquidity);
+        });
+    });
+});
+
+describe("OtfAggregatorOracle#consultLiquidity(token, maxAge = 0)", function () {
+    var underlyingOracle;
+    var oracle;
+
+    beforeEach(async () => {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+        underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        const quoteTokenDecimals = await underlyingOracle.quoteTokenDecimals();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            quoteTokenDecimals: quoteTokenDecimals,
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+    });
+
+    it(`Should get the set liquidity (=(2, 3))`, async () => {
+        const price = LOWEST_ACCEPTABLE_PRICE;
+        const tokenLiqudity = BigNumber.from(2);
+        const quoteTokenLiquidity = BigNumber.from(3);
+
+        await underlyingOracle.stubSetInstantRates(GRT, price, tokenLiqudity, quoteTokenLiquidity);
+
+        const liquitity = await oracle["consultLiquidity(address,uint256)"](GRT, 0);
+
+        expect(liquitity["tokenLiquidity"]).to.equal(tokenLiqudity);
+        expect(liquitity["quoteTokenLiquidity"]).to.equal(quoteTokenLiquidity);
+    });
+});
+
+describe("OtfAggregatorOracle#consultLiquidity(token, maxAge)", function () {
+    const MAX_AGE = 60;
+
+    var oracle;
+    var underlyingOracle;
+
+    const tests = [
+        {
+            args: {
+                price: BigNumber.from(1),
+                tokenLiquidity: BigNumber.from(1),
+                quoteTokenLiquidity: BigNumber.from(1),
+            },
+        },
+        {
+            args: {
+                price: BigNumber.from(1),
+                tokenLiquidity: BigNumber.from(1),
+                quoteTokenLiquidity: BigNumber.from("1000000000000000000"),
+            },
+        },
+        {
+            args: {
+                price: BigNumber.from(1),
+                tokenLiquidity: BigNumber.from("1000000000000000000"),
+                quoteTokenLiquidity: BigNumber.from(1),
+            },
+        },
+        {
+            args: {
+                price: BigNumber.from(1),
+                tokenLiquidity: BigNumber.from("1000000000000000000"),
+                quoteTokenLiquidity: BigNumber.from("1000000000000000000"),
+            },
+        },
+    ];
+
+    beforeEach(async () => {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+        underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        const quoteTokenDecimals = await underlyingOracle.quoteTokenDecimals();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            quoteTokenDecimals: quoteTokenDecimals,
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+        // Time increases by 1 second with each block mined
+        await hre.timeAndMine.setTimeIncrease(1);
+    });
+
+    it("Should revert when there's no observation", async () => {
+        await expect(oracle["consultLiquidity(address,uint256)"](GRT, MAX_AGE)).to.be.revertedWith(
+            "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+        );
+    });
+
+    it("Should revert when the rate is expired (deltaTime > maxAge)", async () => {
+        const observationTime = await currentBlockTimestamp();
+
+        await underlyingOracle.stubSetObservation(GRT, 1, 1, 1, observationTime);
+
+        const time = observationTime + MAX_AGE + 1;
+
+        await hre.timeAndMine.setTime(time);
+
+        expect(await currentBlockTimestamp()).to.equal(time);
+        await expect(oracle["consultLiquidity(address,uint256)"](GRT, MAX_AGE)).to.be.revertedWith(
+            "AbstractOracle: RATE_TOO_OLD"
+        );
+    });
+
+    it("Shouldn't revert when the rate is not expired (deltaTime == maxAge)", async () => {
+        const observationTime = await currentBlockTimestamp();
+
+        await underlyingOracle.stubSetObservation(GRT, 1, 1, 1, observationTime);
+
+        const time = observationTime + MAX_AGE;
+
+        await hre.timeAndMine.setTime(time);
+
+        expect(await currentBlockTimestamp()).to.equal(time);
+        await expect(oracle["consultLiquidity(address,uint256)"](GRT, MAX_AGE)).to.not.be.reverted;
+    });
+
+    it("Shouldn't revert when the rate is not expired (deltaTime < maxAge)", async () => {
+        const observationTime = await currentBlockTimestamp();
+
+        await underlyingOracle.stubSetObservation(GRT, 1, 1, 1, observationTime);
+
+        const time = observationTime + MAX_AGE - 1;
+
+        await hre.timeAndMine.setTime(time);
+
+        expect(await currentBlockTimestamp()).to.equal(time);
+        await expect(oracle["consultLiquidity(address,uint256)"](GRT, MAX_AGE)).to.not.be.reverted;
+    });
+
+    it("Shouldn't revert when the rate is not expired (deltaTime == 0)", async () => {
+        const observationTime = (await currentBlockTimestamp()) + 10;
+
+        await underlyingOracle.stubSetObservation(GRT, 1, 1, 1, observationTime);
+
+        const time = observationTime;
+
+        await hre.timeAndMine.setTime(time);
+
+        expect(await currentBlockTimestamp()).to.equal(time);
+        await expect(oracle["consultLiquidity(address,uint256)"](GRT, MAX_AGE)).to.not.be.reverted;
+    });
+
+    it("Should return fixed values when token == quoteToken", async function () {
+        const [tokenLiqudity, quoteTokenLiquidity] = await oracle["consultLiquidity(address,uint256)"](
+            await oracle.quoteTokenAddress(),
+            MAX_AGE
+        );
+
+        expect(tokenLiqudity).to.equal(0);
+        expect(quoteTokenLiquidity).to.equal(0);
+    });
+
+    tests.forEach(({ args }) => {
+        it(`Should get the set token liquidity (=${args["tokenLiquidity"]}) and quote token liquidity (=${args["quoteTokenLiquidity"]})`, async () => {
+            const _price = args["price"];
+            const _tokenLiqudity = args["tokenLiquidity"];
+            const _quoteTokenLiquidity = args["quoteTokenLiquidity"];
+
+            const observationTime = await currentBlockTimestamp();
+
+            await underlyingOracle.stubSetObservation(
+                GRT,
+                _price,
+                _tokenLiqudity,
+                _quoteTokenLiquidity,
+                observationTime
+            );
+
+            const [tokenLiqudity, quoteTokenLiquidity] = await oracle["consultLiquidity(address,uint256)"](
+                GRT,
+                MAX_AGE
+            );
+
+            expect(tokenLiqudity).to.equal(_tokenLiqudity);
+            expect(quoteTokenLiquidity).to.equal(_quoteTokenLiquidity);
+        });
+    });
+});
+
+describe("OtfAggregatorOracle#consult(token)", function () {
+    describe("Standard consultation tests", function () {
+        var oracle;
+        var underlyingOracle;
+
+        const tests = [
+            {
+                args: {
+                    price: BigNumber.from(1),
+                    tokenLiquidity: BigNumber.from(1),
+                    quoteTokenLiquidity: BigNumber.from(1),
+                },
+            },
+            {
+                args: {
+                    price: BigNumber.from(1),
+                    tokenLiquidity: BigNumber.from(1),
+                    quoteTokenLiquidity: BigNumber.from("1000000000000000000"),
+                },
+            },
+            {
+                args: {
+                    price: BigNumber.from(1),
+                    tokenLiquidity: BigNumber.from("1000000000000000000"),
+                    quoteTokenLiquidity: BigNumber.from(1),
+                },
+            },
+            {
+                args: {
+                    price: BigNumber.from(1),
+                    tokenLiquidity: BigNumber.from("1000000000000000000"),
+                    quoteTokenLiquidity: BigNumber.from("1000000000000000000"),
+                },
+            },
+            {
+                args: {
+                    price: BigNumber.from("1000000000000000000"),
+                    tokenLiquidity: BigNumber.from(1),
+                    quoteTokenLiquidity: BigNumber.from(1),
+                },
+            },
+            {
+                args: {
+                    price: BigNumber.from("1000000000000000000"),
+                    tokenLiquidity: BigNumber.from(1),
+                    quoteTokenLiquidity: BigNumber.from("1000000000000000000"),
+                },
+            },
+            {
+                args: {
+                    price: BigNumber.from("1000000000000000000"),
+                    tokenLiquidity: BigNumber.from("1000000000000000000"),
+                    quoteTokenLiquidity: BigNumber.from(1),
+                },
+            },
+            {
+                args: {
+                    price: BigNumber.from("1000000000000000000"),
+                    tokenLiquidity: BigNumber.from("1000000000000000000"),
+                    quoteTokenLiquidity: BigNumber.from("1000000000000000000"),
+                },
+            },
+        ];
+
+        beforeEach(async () => {
+            const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+            const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+            underlyingOracle = await mockOracleFactory.deploy(USDC);
+            await underlyingOracle.deployed();
+
+            const quoteTokenDecimals = await underlyingOracle.quoteTokenDecimals();
+
+            const constructorOverrides = {
+                validationStrategy: AddressZero,
+                quoteTokenDecimals: quoteTokenDecimals,
+                oracles: [underlyingOracle.address],
+            };
+
+            oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+        });
+
+        it("Should revert when there's no observation", async () => {
+            await expect(oracle["consult(address)"](GRT)).to.be.revertedWith(
+                "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+            );
+        });
+
+        it("Should return fixed values when token == quoteToken", async function () {
+            const [price, tokenLiqudity, quoteTokenLiquidity] = await oracle["consult(address)"](
+                await oracle.quoteTokenAddress()
+            );
+
+            const expectedPrice = ethers.utils.parseUnits("1.0", await oracle.quoteTokenDecimals());
+
+            expect(price).to.equal(expectedPrice);
+            expect(tokenLiqudity).to.equal(0);
+            expect(quoteTokenLiquidity).to.equal(0);
+        });
+
+        tests.forEach(({ args }) => {
+            it(`Should get the set price (=${args["price"]}), token liquidity (=${args["tokenLiquidity"]}), and quote token liquidity (=${args["quoteTokenLiquidity"]})`, async () => {
+                const _price = args["price"];
+                const _tokenLiqudity = args["tokenLiquidity"];
+                const _quoteTokenLiquidity = args["quoteTokenLiquidity"];
+
+                const observationTime = await currentBlockTimestamp();
+
+                await underlyingOracle.stubSetObservation(
+                    GRT,
+                    _price,
+                    _tokenLiqudity,
+                    _quoteTokenLiquidity,
+                    observationTime
+                );
+
+                const [price, tokenLiqudity, quoteTokenLiquidity] = await oracle["consult(address)"](GRT);
+
+                expect(price).to.equal(_price);
+                expect(tokenLiqudity).to.equal(_tokenLiqudity);
+                expect(quoteTokenLiquidity).to.equal(_quoteTokenLiquidity);
+            });
+        });
+    });
+
+    describe("Aggregation tests w/ 1 underlying oracle", function () {
+        const quoteToken = USDC;
+        const token = GRT;
+
+        var underlyingOracle;
+
+        var oracle;
+
+        beforeEach(async () => {
+            // Time increases by 1 second with each block mined
+            await hre.timeAndMine.setTimeIncrease(1);
+
+            const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+            const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+            underlyingOracle = await mockOracleFactory.deploy(quoteToken);
+            await underlyingOracle.deployed();
+
+            await underlyingOracle.stubSetLiquidityDecimals(6);
+
+            const constructorOverrides = {
+                validationStrategy: AddressZero,
+                quoteTokenName: "USD Coin",
+                quoteTokenAddress: quoteToken,
+                quoteTokenSymbol: "USDC",
+                quoteTokenDecimals: 6,
+                liquidityDecimals: 6,
+                oracles: [underlyingOracle.address],
+            };
+
+            oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+        });
+
+        it("Works", async () => {
+            const price = ethers.utils.parseUnits("1", 18);
+            const tokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const quoteTokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const timestamp = (await currentBlockTimestamp()) - 10;
+
+            await underlyingOracle.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(
+                token
+            );
+
+            expect(oPrice).to.equal(price);
+            expect(oTokenLiquidity).to.equal(tokenLiquidity);
+            expect(oQuoteTokenLiquidity).to.equal(quoteTokenLiquidity);
+            expect(oTimestamp).to.equal(timestamp);
+        });
+
+        it("Works with a very high price and the lowest possible liquidity", async () => {
+            // Note: 2^112-1 as the price gets rounded to 2^112 when calculating the harmonic mean (loss of precision).
+            // This can't fit inside a uint112 and SafeCast will throw.
+            const price = BigNumber.from(2).pow(111);
+            const tokenLiquidity = LOWEST_ACCEPTABLE_LIQUIDITY;
+            const quoteTokenLiquidity = LOWEST_ACCEPTABLE_LIQUIDITY;
+            const timestamp = (await currentBlockTimestamp()) - 10;
+
+            await underlyingOracle.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(
+                token
+            );
+
+            expect(oPrice).to.equal(price);
+            expect(oTokenLiquidity).to.equal(tokenLiquidity);
+            expect(oQuoteTokenLiquidity).to.equal(quoteTokenLiquidity);
+            expect(oTimestamp).to.equal(timestamp);
+        });
+
+        it("Has correct price when the oracle has delta +2 quote token decimals", async function () {
+            const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+            const constructorOverrides = {
+                validationStrategy: AddressZero,
+                quoteTokenName: "USD Coin",
+                quoteTokenAddress: quoteToken,
+                quoteTokenSymbol: "USDC",
+                quoteTokenDecimals: 8, // Underlying has 6 decimals, so we set 8 here
+                liquidityDecimals: 6,
+                oracles: [underlyingOracle.address],
+            };
+
+            oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+            const price = ethers.utils.parseUnits("1", 18);
+            const tokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const quoteTokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const timestamp = (await currentBlockTimestamp()) - 10;
+
+            await underlyingOracle.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            // Increase by 2 decimal places (delta from underlying is +2), so multiply by 10^2
+            const expectedPrice = price.mul(100);
+
+            const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(
+                token
+            );
+
+            expect(oPrice).to.equal(expectedPrice);
+            expect(oTokenLiquidity).to.equal(tokenLiquidity);
+            expect(oQuoteTokenLiquidity).to.equal(quoteTokenLiquidity);
+            expect(oTimestamp).to.equal(timestamp);
+        });
+
+        it("Has correct price when the oracle has delta -2 quote token decimals", async function () {
+            const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+            const constructorOverrides = {
+                validationStrategy: AddressZero,
+                quoteTokenName: "USD Coin",
+                quoteTokenAddress: quoteToken,
+                quoteTokenSymbol: "USDC",
+                quoteTokenDecimals: 4, // Underlying has 6 decimals, so we set 4 here
+                liquidityDecimals: 6,
+                oracles: [underlyingOracle.address],
+            };
+
+            oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+            const price = ethers.utils.parseUnits("1", 18);
+            const tokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const quoteTokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const timestamp = (await currentBlockTimestamp()) - 10;
+
+            await underlyingOracle.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            // Decrease by 2 decimal places (delta from underlying is -2), so divide by 10^2
+            const expectedPrice = price.div(100);
+
+            const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(
+                token
+            );
+
+            expect(oPrice).to.equal(expectedPrice);
+            expect(oTokenLiquidity).to.equal(tokenLiquidity);
+            expect(oQuoteTokenLiquidity).to.equal(quoteTokenLiquidity);
+            expect(oTimestamp).to.equal(timestamp);
+        });
+
+        it("Has correct liquidity when the oracle has delta +2 liquidity decimals", async function () {
+            const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+            const constructorOverrides = {
+                validationStrategy: AddressZero,
+                quoteTokenName: "USD Coin",
+                quoteTokenAddress: quoteToken,
+                quoteTokenSymbol: "USDC",
+                quoteTokenDecimals: 6,
+                liquidityDecimals: 8, // Underlying has 6 decimals, so we set 8 here
+                oracles: [underlyingOracle.address],
+            };
+
+            oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+            const price = ethers.utils.parseUnits("1", 18);
+            const tokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const quoteTokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const timestamp = (await currentBlockTimestamp()) - 10;
+
+            await underlyingOracle.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            // Increase by 2 decimal places (delta from underlying is +2), so multiply by 10^2
+            const expectedTokenLiquidity = tokenLiquidity.mul(100);
+            const expectedQuoteTokenLiquidity = quoteTokenLiquidity.mul(100);
+
+            const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(
+                token
+            );
+
+            expect(oPrice).to.equal(price);
+            expect(oTokenLiquidity).to.equal(expectedTokenLiquidity);
+            expect(oQuoteTokenLiquidity).to.equal(expectedQuoteTokenLiquidity);
+            expect(oTimestamp).to.equal(timestamp);
+        });
+
+        it("Has correct liquidity when the oracle has delta -2 liquidity decimals", async function () {
+            const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+            const constructorOverrides = {
+                validationStrategy: AddressZero,
+                quoteTokenName: "USD Coin",
+                quoteTokenAddress: quoteToken,
+                quoteTokenSymbol: "USDC",
+                quoteTokenDecimals: 6,
+                liquidityDecimals: 4, // Underlying has 6 decimals, so we set 4 here
+                oracles: [underlyingOracle.address],
+            };
+
+            oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+            const price = ethers.utils.parseUnits("1", 18);
+            const tokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const quoteTokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const timestamp = (await currentBlockTimestamp()) - 10;
+
+            await underlyingOracle.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            // Decrease by 2 decimal places (delta from underlying is -2), so divide by 10^2
+            const expectedTokenLiquidity = tokenLiquidity.div(100);
+            const expectedQuoteTokenLiquidity = quoteTokenLiquidity.div(100);
+
+            const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(
+                token
+            );
+
+            expect(oPrice).to.equal(price);
+            expect(oTokenLiquidity).to.equal(expectedTokenLiquidity);
+            expect(oQuoteTokenLiquidity).to.equal(expectedQuoteTokenLiquidity);
+            expect(oTimestamp).to.equal(timestamp);
+        });
+
+        it("Shouldn't use old rates", async () => {
+            const price = ethers.utils.parseUnits("1", 18);
+            const tokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const quoteTokenLiquidity = ethers.utils.parseUnits("1", 18);
+
+            // Setting the observation below will increase the time past the threshold
+            const timestamp = (await currentBlockTimestamp()) - DEFAULT_MIN_FRESHNESS;
+
+            await underlyingOracle.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            await expect(oracle.getLatestObservation(token)).to.be.revertedWith(
+                "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+            );
+        });
+
+        it("Should catch underlying consult errors and revert", async () => {
+            const price = ethers.utils.parseUnits("1", 18);
+            const tokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const quoteTokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const timestamp = (await currentBlockTimestamp()) - 10;
+
+            await underlyingOracle.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            const [poPrice, poTokenLiquidity, poQuoteTokenLiquidity, poTimestamp] = await oracle.getLatestObservation(
+                token
+            );
+
+            // Sanity check that the oracle has a valid observation
+            expect(poPrice).to.equal(price);
+            expect(poTokenLiquidity).to.equal(tokenLiquidity);
+            expect(poQuoteTokenLiquidity).to.equal(quoteTokenLiquidity);
+            expect(poTimestamp).to.equal(timestamp);
+
+            // Now set the underlying oracle to return an error
+            await underlyingOracle.stubSetConsultError(true);
+
+            await expect(oracle.getLatestObservation(token)).to.be.revertedWith(
+                "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+            );
+        });
+
+        it("Should revert when there aren't any valid consultations", async () => {
+            await expect(oracle.getLatestObservation(token)).to.be.revertedWith(
+                "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+            );
+        });
+
+        it("Should revert when the underlying oracle's price is 0", async () => {
+            // Deploy the aggregator with the default validation strategy
+            const constructorOverrides = {
+                quoteTokenName: "USD Coin",
+                quoteTokenAddress: quoteToken,
+                quoteTokenSymbol: "USDC",
+                quoteTokenDecimals: 6,
+                liquidityDecimals: 6,
+                oracles: [underlyingOracle.address],
+            };
+            const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+            oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+            const price = BigNumber.from(0);
+            const tokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const quoteTokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const timestamp = (await currentBlockTimestamp()) - 10;
+
+            await underlyingOracle.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            await expect(oracle.getLatestObservation(token)).to.be.revertedWith(
+                "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+            );
+        });
+
+        it("Should revert when the underlying oracle's quote token liquidity is 0", async () => {
+            // Deploy the aggregator with the default validation strategy
+            const constructorOverrides = {
+                quoteTokenName: "USD Coin",
+                quoteTokenAddress: quoteToken,
+                quoteTokenSymbol: "USDC",
+                quoteTokenDecimals: 6,
+                liquidityDecimals: 6,
+                oracles: [underlyingOracle.address],
+            };
+            const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+            oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+            const price = ethers.utils.parseUnits("1", 18);
+            const tokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const quoteTokenLiquidity = BigNumber.from(0);
+            const timestamp = (await currentBlockTimestamp()) - 10;
+
+            await underlyingOracle.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            await expect(oracle.getLatestObservation(token)).to.be.revertedWith(
+                "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+            );
+        });
+
+        it("Should revert when the underlying oracle's price and quote token liquidity is 0", async () => {
+            // Deploy the aggregator with the default validation strategy
+            const constructorOverrides = {
+                quoteTokenName: "USD Coin",
+                quoteTokenAddress: quoteToken,
+                quoteTokenSymbol: "USDC",
+                quoteTokenDecimals: 6,
+                liquidityDecimals: 6,
+                oracles: [underlyingOracle.address],
+            };
+            const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+            oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+            const price = BigNumber.from(0);
+            const tokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const quoteTokenLiquidity = BigNumber.from(0);
+            const timestamp = (await currentBlockTimestamp()) - 10;
+
+            await underlyingOracle.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            await expect(oracle.getLatestObservation(token)).to.be.revertedWith(
+                "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+            );
+        });
+    });
+
+    describe("Aggregation tests w/ 2 underlying oracle", function () {
+        const quoteToken = USDC;
+        const token = GRT;
+
+        var underlyingOracle1;
+        var underlyingOracle2;
+
+        var oracle;
+
+        beforeEach(async () => {
+            // Time increases by 1 second with each block mined
+            await hre.timeAndMine.setTimeIncrease(1);
+
+            const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+            const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+            underlyingOracle1 = await mockOracleFactory.deploy(quoteToken);
+            await underlyingOracle1.deployed();
+
+            underlyingOracle2 = await mockOracleFactory.deploy(quoteToken);
+            await underlyingOracle2.deployed();
+
+            const constructorOverrides = {
+                validationStrategy: AddressZero,
+                quoteTokenName: "USD Coin",
+                quoteTokenAddress: quoteToken,
+                quoteTokenSymbol: "USDC",
+                quoteTokenDecimals: 6,
+                liquidityDecimals: 0,
+                oracles: [underlyingOracle1.address, underlyingOracle2.address],
+            };
+
+            oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+        });
+
+        it("Should set observation liquitities to (2^112)-1 when total liquitities >= 2^112", async function () {
+            var price = ethers.utils.parseUnits("1", 18);
+            const tokenLiquidity = BigNumber.from(2).pow(112).sub(1);
+            const quoteTokenLiquidity = BigNumber.from(2).pow(112).sub(1);
+            const timestamp = (await currentBlockTimestamp()) - 10;
+
+            await underlyingOracle1.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            await underlyingOracle2.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            // Liquitities will overflow uint112, so rather than having the update fail, we set the observation liquitities
+            // to the max supported value.
+            const totalTokenLiquidity = BigNumber.from(2).pow(112).sub(1);
+            const totalQuoteTokenLiquidity = BigNumber.from(2).pow(112).sub(1);
+
+            const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(
+                token
+            );
+
+            expect(oPrice, "Observation price").to.equal(price);
+            expect(oTokenLiquidity, "Observation token liquidity").to.equal(totalTokenLiquidity);
+            expect(oQuoteTokenLiquidity, "Observation quote token liquidity").to.equal(totalQuoteTokenLiquidity);
+            expect(oTimestamp, "Observation timestamp").to.equal(timestamp);
+        });
+
+        it("Should work successfully w/ same prices and liquidities", async () => {
+            const price = ethers.utils.parseUnits("1", 18);
+            const tokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const quoteTokenLiquidity = ethers.utils.parseUnits("1", 18);
+            const timestamp = (await currentBlockTimestamp()) - 10;
+
+            await underlyingOracle1.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            await underlyingOracle2.stubSetObservation(token, price, tokenLiquidity, quoteTokenLiquidity, timestamp);
+
+            const totalTokenLiquidity = tokenLiquidity.mul(2);
+            const totalQuoteTokenLiquidity = quoteTokenLiquidity.mul(2);
+
+            const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(
+                token
+            );
+
+            expect(oPrice).to.equal(price);
+            expect(oTokenLiquidity).to.equal(totalTokenLiquidity);
+            expect(oQuoteTokenLiquidity).to.equal(totalQuoteTokenLiquidity);
+            expect(oTimestamp).to.equal(timestamp);
+        });
+
+        it("Should work successfully w/ differing prices and liquidities", async () => {
+            const price1 = ethers.utils.parseUnits("1", 18);
+            const tokenLiquidity1 = ethers.utils.parseUnits("1", 18);
+            const quoteTokenLiquidity1 = ethers.utils.parseUnits("1", 18);
+
+            const price2 = ethers.utils.parseUnits("2", 18);
+            const tokenLiquidity2 = ethers.utils.parseUnits("1000", 18);
+            const quoteTokenLiquidity2 = ethers.utils.parseUnits("2000", 18);
+
+            const timestamp = (await currentBlockTimestamp()) - 10;
+
+            await underlyingOracle1.stubSetObservation(token, price1, tokenLiquidity1, quoteTokenLiquidity1, timestamp);
+
+            await underlyingOracle2.stubSetObservation(token, price2, tokenLiquidity2, quoteTokenLiquidity2, timestamp);
+
+            const totalTokenLiquidity = tokenLiquidity1.add(tokenLiquidity2);
+            const totalQuoteTokenLiquidity = quoteTokenLiquidity1.add(quoteTokenLiquidity2);
+
+            // = ~1.99 => looks good
+            const expectedPrice = harmonicMean([price1, price2], [quoteTokenLiquidity1, quoteTokenLiquidity2]);
+
+            const [oPrice, oTokenLiquidity, oQuoteTokenLiquidity, oTimestamp] = await oracle.getLatestObservation(
+                token
+            );
+
+            expect(oPrice).to.equal(expectedPrice);
+            expect(oTokenLiquidity).to.equal(totalTokenLiquidity);
+            expect(oQuoteTokenLiquidity).to.equal(totalQuoteTokenLiquidity);
+            expect(oTimestamp).to.equal(timestamp);
+        });
+    });
+});
+
+describe("OtfAggregatorOracle#consult(token, maxAge = 0)", function () {
+    var oracleFactory;
+    var mockOracleFactory;
+    var underlyingOracle;
+    var oracle;
+
+    beforeEach(async () => {
+        mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+        underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        const quoteTokenDecimals = await underlyingOracle.quoteTokenDecimals();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            quoteTokenDecimals: quoteTokenDecimals,
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+    });
+
+    it(`Should get the set price (=${LOWEST_ACCEPTABLE_PRICE})`, async () => {
+        const price = LOWEST_ACCEPTABLE_PRICE;
+        const tokenLiqudity = BigNumber.from(2);
+        const quoteTokenLiquidity = BigNumber.from(3);
+
+        await underlyingOracle.stubSetInstantRates(GRT, price, tokenLiqudity, quoteTokenLiquidity);
+
+        const consultation = await oracle["consult(address,uint256)"](GRT, 0);
+
+        expect(consultation["price"]).to.equal(price);
+        expect(consultation["tokenLiquidity"]).to.equal(tokenLiqudity);
+        expect(consultation["quoteTokenLiquidity"]).to.equal(quoteTokenLiquidity);
+    });
+
+    it("Should revert when there are no valid responses", async function () {
+        await underlyingOracle.stubSetConsultError(true);
+
+        await expect(oracle["consult(address,uint256)"](GRT, 0)).to.be.revertedWith(
+            "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+        );
+    });
+
+    it("Should revert when the price exceeds uint112.max", async function () {
+        const aggregationStrategyFactory = await ethers.getContractFactory("DefaultAggregator");
+        const aggregationStrategy = await aggregationStrategyFactory.deploy();
+        await aggregationStrategy.deployed();
+
+        // Redeploy with more quote token decimal places
+        const quoteTokenDecimals = await underlyingOracle.quoteTokenDecimals();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            quoteTokenDecimals: quoteTokenDecimals + 1,
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+        const price = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+        const tokenLiqudity = BigNumber.from(200);
+        const quoteTokenLiquidity = BigNumber.from(300);
+
+        await underlyingOracle.stubSetInstantRates(GRT, price, tokenLiqudity, quoteTokenLiquidity);
+
+        // Sanity checks
+        expect(await underlyingOracle.quoteTokenDecimals()).to.equal(
+            6,
+            "Underlying oracle should use 6 decimals for the price"
+        );
+        expect(await oracle.quoteTokenDecimals()).to.equal(7, "Aggregated oracle should use 7 decimals for the price");
+
+        await expect(oracle["consult(address,uint256)"](GRT, 0)).to.be.reverted;
+    });
+
+    it("Should report token liquidity of uint112.max when it exceeds that", async function () {
+        const aggregationStrategyFactory = await ethers.getContractFactory("DefaultAggregator");
+        const aggregationStrategy = await aggregationStrategyFactory.deploy();
+        await aggregationStrategy.deployed();
+
+        const underlyingOracle2 = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle2.deployed();
+
+        // Redeploy with additional underlying oracle
+        const quoteTokenDecimals = await underlyingOracle.quoteTokenDecimals();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            quoteTokenDecimals: quoteTokenDecimals,
+            oracles: [underlyingOracle.address, underlyingOracle2.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+        const price = LOWEST_ACCEPTABLE_PRICE;
+        const tokenLiqudity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+        const quoteTokenLiquidity = LOWEST_ACCEPTABLE_LIQUIDITY;
+
+        await underlyingOracle.stubSetInstantRates(GRT, price, tokenLiqudity, quoteTokenLiquidity);
+        await underlyingOracle2.stubSetInstantRates(GRT, price, tokenLiqudity, quoteTokenLiquidity);
+
+        const totalTokenLiquidity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+        const totalQuoteTokenLiquidity = quoteTokenLiquidity.mul(2);
+
+        const consultation = await oracle["consult(address,uint256)"](GRT, 0);
+
+        expect(consultation["price"]).to.equal(price);
+        expect(consultation["tokenLiquidity"]).to.equal(totalTokenLiquidity);
+        expect(consultation["quoteTokenLiquidity"]).to.equal(totalQuoteTokenLiquidity);
+    });
+
+    it("Should report quote token liquidity of uint112.max when it exceeds that", async function () {
+        const aggregationStrategyFactory = await ethers.getContractFactory("DefaultAggregator");
+        const aggregationStrategy = await aggregationStrategyFactory.deploy();
+        await aggregationStrategy.deployed();
+
+        const underlyingOracle2 = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle2.deployed();
+
+        // Redeploy with additional underlying oracle
+        const quoteTokenDecimals = await underlyingOracle.quoteTokenDecimals();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            quoteTokenDecimals: quoteTokenDecimals,
+            oracles: [underlyingOracle.address, underlyingOracle2.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+        const price = LOWEST_ACCEPTABLE_PRICE;
+        const tokenLiqudity = LOWEST_ACCEPTABLE_LIQUIDITY;
+        const quoteTokenLiquidity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+
+        await underlyingOracle.stubSetInstantRates(GRT, price, tokenLiqudity, quoteTokenLiquidity);
+        await underlyingOracle2.stubSetInstantRates(GRT, price, tokenLiqudity, quoteTokenLiquidity);
+
+        const totalTokenLiquidity = tokenLiqudity.mul(2);
+        const totalQuoteTokenLiquidity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+
+        const consultation = await oracle["consult(address,uint256)"](GRT, 0);
+
+        expect(consultation["price"]).to.equal(price);
+        expect(consultation["tokenLiquidity"]).to.equal(totalTokenLiquidity);
+        expect(consultation["quoteTokenLiquidity"]).to.equal(totalQuoteTokenLiquidity);
+    });
+
+    it("Should report liquidities of uint112.max when they exceeds that", async function () {
+        const aggregationStrategyFactory = await ethers.getContractFactory("DefaultAggregator");
+        const aggregationStrategy = await aggregationStrategyFactory.deploy();
+        await aggregationStrategy.deployed();
+
+        const underlyingOracle2 = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle2.deployed();
+
+        // Redeploy with additional underlying oracle
+        const quoteTokenDecimals = await underlyingOracle.quoteTokenDecimals();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            quoteTokenDecimals: quoteTokenDecimals,
+            oracles: [underlyingOracle.address, underlyingOracle2.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+        const price = LOWEST_ACCEPTABLE_PRICE;
+        const tokenLiqudity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+        const quoteTokenLiquidity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+
+        await underlyingOracle.stubSetInstantRates(GRT, price, tokenLiqudity, quoteTokenLiquidity);
+        await underlyingOracle2.stubSetInstantRates(GRT, price, tokenLiqudity, quoteTokenLiquidity);
+
+        const totalTokenLiquidity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+        const totalQuoteTokenLiquidity = BigNumber.from(2).pow(112).sub(1); // = uint112.max
+
+        const consultation = await oracle["consult(address,uint256)"](GRT, 0);
+
+        expect(consultation["price"]).to.equal(price);
+        expect(consultation["tokenLiquidity"]).to.equal(totalTokenLiquidity);
+        expect(consultation["quoteTokenLiquidity"]).to.equal(totalQuoteTokenLiquidity);
+    });
+});
+
+describe("OtfAggregatorOracle#consult(token, maxAge)", function () {
+    const MAX_AGE = 60;
+
+    var oracle;
+    var underlyingOracle;
+
+    const tests = [
+        {
+            args: {
+                price: BigNumber.from(1),
+                tokenLiquidity: BigNumber.from(1),
+                quoteTokenLiquidity: BigNumber.from(1),
+            },
+        },
+        {
+            args: {
+                price: BigNumber.from(1),
+                tokenLiquidity: BigNumber.from(1),
+                quoteTokenLiquidity: BigNumber.from("1000000000000000000"),
+            },
+        },
+        {
+            args: {
+                price: BigNumber.from(1),
+                tokenLiquidity: BigNumber.from("1000000000000000000"),
+                quoteTokenLiquidity: BigNumber.from(1),
+            },
+        },
+        {
+            args: {
+                price: BigNumber.from(1),
+                tokenLiquidity: BigNumber.from("1000000000000000000"),
+                quoteTokenLiquidity: BigNumber.from("1000000000000000000"),
+            },
+        },
+        {
+            args: {
+                price: BigNumber.from("1000000000000000000"),
+                tokenLiquidity: BigNumber.from(1),
+                quoteTokenLiquidity: BigNumber.from(1),
+            },
+        },
+        {
+            args: {
+                price: BigNumber.from("1000000000000000000"),
+                tokenLiquidity: BigNumber.from(1),
+                quoteTokenLiquidity: BigNumber.from("1000000000000000000"),
+            },
+        },
+        {
+            args: {
+                price: BigNumber.from("1000000000000000000"),
+                tokenLiquidity: BigNumber.from("1000000000000000000"),
+                quoteTokenLiquidity: BigNumber.from(1),
+            },
+        },
+        {
+            args: {
+                price: BigNumber.from("1000000000000000000"),
+                tokenLiquidity: BigNumber.from("1000000000000000000"),
+                quoteTokenLiquidity: BigNumber.from("1000000000000000000"),
+            },
+        },
+    ];
+
+    beforeEach(async () => {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+        underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        const quoteTokenDecimals = await underlyingOracle.quoteTokenDecimals();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            quoteTokenDecimals: quoteTokenDecimals,
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+
+        // Time increases by 1 second with each block mined
+        await hre.timeAndMine.setTimeIncrease(1);
+    });
+
+    it("Should revert when there's no observation", async () => {
+        await expect(oracle["consult(address,uint256)"](GRT, MAX_AGE)).to.be.revertedWith(
+            "AbstractAggregatorOracle: INVALID_NUM_CONSULTATIONS"
+        );
+    });
+
+    it("Should revert when the rate is expired (deltaTime > maxAge)", async () => {
+        const observationTime = await currentBlockTimestamp();
+
+        await underlyingOracle.stubSetObservation(GRT, 1, 1, 1, observationTime);
+
+        const time = observationTime + MAX_AGE + 1;
+
+        await hre.timeAndMine.setTime(time);
+
+        expect(await currentBlockTimestamp()).to.equal(time);
+        await expect(oracle["consult(address,uint256)"](GRT, MAX_AGE)).to.be.revertedWith(
+            "AbstractOracle: RATE_TOO_OLD"
+        );
+    });
+
+    it("Shouldn't revert when the rate is not expired (deltaTime == maxAge)", async () => {
+        const observationTime = await currentBlockTimestamp();
+
+        await underlyingOracle.stubSetObservation(GRT, 1, 1, 1, observationTime);
+
+        const time = observationTime + MAX_AGE;
+
+        await hre.timeAndMine.setTime(time);
+
+        expect(await currentBlockTimestamp()).to.equal(time);
+        await expect(oracle["consult(address,uint256)"](GRT, MAX_AGE)).to.not.be.reverted;
+    });
+
+    it("Shouldn't revert when the rate is not expired (deltaTime < maxAge)", async () => {
+        const observationTime = await currentBlockTimestamp();
+
+        await underlyingOracle.stubSetObservation(GRT, 1, 1, 1, observationTime);
+
+        const time = observationTime + MAX_AGE - 1;
+
+        await hre.timeAndMine.setTime(time);
+
+        expect(await currentBlockTimestamp()).to.equal(time);
+        await expect(oracle["consult(address,uint256)"](GRT, MAX_AGE)).to.not.be.reverted;
+    });
+
+    it("Shouldn't revert when the rate is not expired (deltaTime == 0)", async () => {
+        const observationTime = (await currentBlockTimestamp()) + 10;
+
+        await underlyingOracle.stubSetObservation(GRT, 1, 1, 1, observationTime);
+
+        const time = observationTime;
+
+        await hre.timeAndMine.setTime(time);
+
+        expect(await currentBlockTimestamp()).to.equal(time);
+        await expect(oracle["consult(address,uint256)"](GRT, MAX_AGE)).to.not.be.reverted;
+    });
+
+    it("Should return fixed values when token == quoteToken", async function () {
+        const [price, tokenLiqudity, quoteTokenLiquidity] = await oracle["consult(address,uint256)"](
+            await oracle.quoteTokenAddress(),
+            MAX_AGE
+        );
+
+        const expectedPrice = ethers.utils.parseUnits("1.0", await oracle.quoteTokenDecimals());
+
+        expect(price).to.equal(expectedPrice);
+        expect(tokenLiqudity).to.equal(0);
+        expect(quoteTokenLiquidity).to.equal(0);
+    });
+
+    tests.forEach(({ args }) => {
+        it(`Should get the set price (=${args["price"]}), token liquidity (=${args["tokenLiquidity"]}), and quote token liquidity (=${args["quoteTokenLiquidity"]})`, async () => {
+            const _price = args["price"];
+            const _tokenLiqudity = args["tokenLiquidity"];
+            const _quoteTokenLiquidity = args["quoteTokenLiquidity"];
+
+            const observationTime = await currentBlockTimestamp();
+
+            await underlyingOracle.stubSetObservation(
+                GRT,
+                _price,
+                _tokenLiqudity,
+                _quoteTokenLiquidity,
+                observationTime
+            );
+
+            const [price, tokenLiqudity, quoteTokenLiquidity] = await oracle["consult(address,uint256)"](GRT, MAX_AGE);
+
+            expect(price).to.equal(_price);
+            expect(tokenLiqudity).to.equal(_tokenLiqudity);
+            expect(quoteTokenLiquidity).to.equal(_quoteTokenLiquidity);
+        });
+    });
+});
+
+describe("OtfAggregatorOracle#update", function () {
+    var oracle;
+
+    beforeEach(async () => {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+        const underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+    });
+
+    it("Reverts called", async () => {
+        const updateData = ethers.utils.defaultAbiCoder.encode(["address"], [GRT]);
+        await expect(oracle.update(updateData)).to.be.revertedWith("Not supported");
+    });
+});
+
+describe("OtfAggregatorOracle - IHistoricalOracle implementation", function () {
+    var oracle;
+
+    beforeEach(async () => {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+
+        const underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+    });
+
+    it("Reverts when getObservationAt is called", async () => {
+        await expect(oracle.getObservationAt(GRT, 0)).to.be.revertedWith("Not supported");
+    });
+
+    it("Reverts when getObservations(address,uint256) is called", async () => {
+        await expect(oracle["getObservations(address,uint256)"](GRT, 0)).to.be.revertedWith("Not supported");
+    });
+
+    it("Reverts when getObservations(address,uint256,uint256,uint256) is called", async () => {
+        await expect(oracle["getObservations(address,uint256,uint256,uint256)"](GRT, 0, 0, 0)).to.be.revertedWith(
+            "Not supported"
+        );
+    });
+
+    it("Reverts when getObservationsCount is called", async () => {
+        await expect(oracle.getObservationsCount(GRT)).to.be.revertedWith("Not supported");
+    });
+
+    it("Reverts when getObservationsCapacity is called", async () => {
+        await expect(oracle.getObservationsCapacity(GRT)).to.be.revertedWith("Not supported");
+    });
+
+    it("Reverts when setObservationsCapacity is called", async () => {
+        await expect(oracle.setObservationsCapacity(GRT, 100)).to.be.revertedWith("Not supported");
+    });
+});
+
+describe("OtfAggregatorOracle#supportsInterface(interfaceId)", function () {
+    var oracle;
+    var interfaceIds;
+
+    beforeEach(async () => {
+        const mockOracleFactory = await ethers.getContractFactory("MockOracle");
+        const oracleFactory = await ethers.getContractFactory("OtfAggregatorOracle");
+        const interfaceIdsFactory = await ethers.getContractFactory("InterfaceIds");
+
+        const underlyingOracle = await mockOracleFactory.deploy(USDC);
+        await underlyingOracle.deployed();
+
+        const constructorOverrides = {
+            validationStrategy: AddressZero,
+            oracles: [underlyingOracle.address],
+        };
+
+        oracle = await constructDefaultAggregator(oracleFactory, constructorOverrides);
+        interfaceIds = await interfaceIdsFactory.deploy();
+    });
+
+    it("Should support IOracleAggregator", async () => {
+        const interfaceId = await interfaceIds.iOracleAggregator();
+        expect(await oracle["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
+    });
+
+    it("Should support IOracle", async () => {
+        const interfaceId = await interfaceIds.iOracle();
+        expect(await oracle["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
+    });
+
+    it("Should support IPriceOracle", async () => {
+        const interfaceId = await interfaceIds.iPriceOracle();
+        expect(await oracle["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
+    });
+
+    it("Should support ILiquidityOracle", async () => {
+        const interfaceId = await interfaceIds.iLiquidityOracle();
+        expect(await oracle["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
+    });
+
+    it("Should support IQuoteToken", async () => {
+        const interfaceId = await interfaceIds.iQuoteToken();
+        expect(await oracle["supportsInterface(bytes4)"](interfaceId)).to.equal(true);
+    });
+
+    it("Doesn't support IUpdateable", async () => {
+        const interfaceId = await interfaceIds.iUpdateable();
+        expect(await oracle["supportsInterface(bytes4)"](interfaceId)).to.equal(false);
+    });
+
+    it("Doesn't support IHistoricalOracle", async () => {
+        const interfaceId = await interfaceIds.iHistoricalOracle();
+        expect(await oracle["supportsInterface(bytes4)"](interfaceId)).to.equal(false);
+    });
+});

--- a/test/oracles/views/external-oracle-view.js
+++ b/test/oracles/views/external-oracle-view.js
@@ -862,17 +862,21 @@ function describeTests(contractName, createDefaultOracle, maxPriceBits, priceIsS
             const answer = ethers.utils.parseUnits("3", decimals);
             await feed.setRoundDataNow(answer);
 
-            expect(await oracle["consultLiquidity(address,uint256)"](feedToken, 0)).to.deep.equal([
-                ethers.constants.Zero,
-                ethers.constants.Zero,
-            ]);
+            const [tokenLiquidity, quoteTokenLiquidity] = await oracle["consultLiquidity(address,uint256)"](
+                feedToken,
+                0
+            );
+            expect(tokenLiquidity).to.equal(ethers.constants.Zero);
+            expect(quoteTokenLiquidity).to.equal(ethers.constants.Zero);
         });
 
         it("Returns zero liquidity for the token and quote token, when the token is the quote token", async function () {
-            expect(await oracle["consultLiquidity(address,uint256)"](quoteToken, 0)).to.deep.equal([
-                ethers.constants.Zero,
-                ethers.constants.Zero,
-            ]);
+            const [tokenLiquidity, quoteTokenLiquidity] = await oracle["consultLiquidity(address,uint256)"](
+                quoteToken,
+                0
+            );
+            expect(tokenLiquidity).to.equal(ethers.constants.Zero);
+            expect(quoteTokenLiquidity).to.equal(ethers.constants.Zero);
         });
 
         it("Reverts if the token does not match the feed token", async function () {
@@ -952,17 +956,15 @@ function describeTests(contractName, createDefaultOracle, maxPriceBits, priceIsS
             const answer = ethers.utils.parseUnits("3", decimals);
             await feed.setRoundDataNow(answer);
 
-            expect(await oracle["consultLiquidity(address)"](feedToken)).to.deep.equal([
-                ethers.constants.Zero,
-                ethers.constants.Zero,
-            ]);
+            const [tokenLiquidity, quoteTokenLiquidity] = await oracle["consultLiquidity(address)"](feedToken);
+            expect(tokenLiquidity).to.equal(ethers.constants.Zero);
+            expect(quoteTokenLiquidity).to.equal(ethers.constants.Zero);
         });
 
         it("Returns zero liquidity for the token and quote token, when the token is the quote token", async function () {
-            expect(await oracle["consultLiquidity(address)"](quoteToken)).to.deep.equal([
-                ethers.constants.Zero,
-                ethers.constants.Zero,
-            ]);
+            const [tokenLiquidity, quoteTokenLiquidity] = await oracle["consultLiquidity(address)"](quoteToken);
+            expect(tokenLiquidity).to.equal(ethers.constants.Zero);
+            expect(quoteTokenLiquidity).to.equal(ethers.constants.Zero);
         });
 
         it("Reverts if the token does not match the feed token", async function () {

--- a/test/oracles/views/external-oracle-view.js
+++ b/test/oracles/views/external-oracle-view.js
@@ -1,12 +1,18 @@
 const { BigNumber } = require("ethers");
 const { expect } = require("chai");
-const { ethers } = require("hardhat");
+const hre = require("hardhat");
+const forkingConfig = require("../../../forking").default;
+
+const { ethers, timeAndMine } = hre;
 
 const AddressZero = ethers.constants.AddressZero;
 
 const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const GRT = "0xc944E90C64B2c07662A292be6244BDf05Cda44a7";
 const DAI = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
+const WBTC = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599";
+
+const NATIVE_BNB = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB";
 
 const DEFAULT_CONFIDENCE_DECIMALS = 8;
 const DEFAULT_MIN_CONFIDENCE = ethers.utils.parseUnits("0.95", DEFAULT_CONFIDENCE_DECIMALS); // 95%
@@ -20,6 +26,40 @@ async function currentBlockTimestamp() {
 
 async function blockTimestamp(blockNum) {
     return (await ethers.provider.getBlock(blockNum)).timestamp;
+}
+
+async function deployVenusOracle(feedToken, quoteTokenDecimals) {
+    const oracleFactory = await ethers.getContractFactory("VenusOracleStub");
+    const oracle = await oracleFactory.deploy(feedToken, quoteTokenDecimals);
+    await oracle.deployed();
+
+    return oracle;
+}
+
+async function createDefaultVenusOracle(feedToken, quoteToken, contractName = "VenusOracleView", overrides = {}) {
+    let quoteTokenDecimals = overrides.quoteTokenDecimals;
+
+    if (quoteTokenDecimals == null) {
+        const quoteTokenContract = await ethers.getContractAt(
+            "@openzeppelin-v4/contracts/token/ERC20/ERC20.sol:ERC20",
+            quoteToken
+        );
+
+        quoteTokenDecimals = await quoteTokenContract.decimals();
+    }
+
+    let quoteTokenName = overrides.quoteTokenName ?? "NAME";
+    let quoteTokenSymbol = overrides.quoteTokenSymbol ?? "SYMBOL";
+
+    const feed = await deployVenusOracle(feedToken, quoteTokenDecimals);
+    const factory = await ethers.getContractFactory(contractName);
+    const oracle = await factory.deploy(feed.address, quoteTokenName, quoteToken, quoteTokenSymbol, quoteTokenDecimals);
+    await oracle.deployed();
+
+    return {
+        feed: feed,
+        oracle: oracle,
+    };
 }
 
 async function deployChainlinkFeed(quoteTokenDecimals) {
@@ -289,6 +329,166 @@ describe("DiaOracleView#constructor", function () {
     });
 });
 
+describe("VenusOracleView#constructor", function () {
+    it("Deploys correctly", async function () {
+        const feedToken = GRT;
+        const quoteToken = USDC;
+        const quoteTokenName = "NAME";
+        const quoteTokenSymbol = "SYMBOL";
+        const quoteTokenDecimals = 6;
+        const deployment = await createDefaultVenusOracle(feedToken, quoteToken, "VenusOracleView", {
+            quoteTokenSymbol: quoteTokenSymbol,
+            quoteTokenName: quoteTokenName,
+            quoteTokenDecimals: quoteTokenDecimals,
+        });
+
+        const oracle = deployment.oracle;
+        const feed = deployment.feed;
+
+        expect(await oracle.getUnderlyingFeed()).to.equal(feed.address);
+        expect(await oracle.quoteTokenName()).to.equal(quoteTokenName);
+        expect(await oracle.quoteTokenAddress()).to.equal(quoteToken);
+        expect(await oracle.quoteTokenSymbol()).to.equal(quoteTokenSymbol);
+        expect(await oracle.quoteTokenDecimals()).to.equal(quoteTokenDecimals);
+        expect(await oracle.liquidityDecimals()).to.equal(0);
+    });
+
+    it("Deploys correctly with alternative parameters", async function () {
+        const feedToken = WBTC;
+        const quoteToken = DAI;
+        const quoteTokenName = "NAME2";
+        const quoteTokenSymbol = "SYMBOL2";
+        const quoteTokenDecimals = 18;
+        const deployment = await createDefaultVenusOracle(feedToken, quoteToken, "VenusOracleView", {
+            quoteTokenSymbol: quoteTokenSymbol,
+            quoteTokenName: quoteTokenName,
+            quoteTokenDecimals: quoteTokenDecimals,
+        });
+
+        const oracle = deployment.oracle;
+        const feed = deployment.feed;
+
+        expect(await oracle.getUnderlyingFeed()).to.equal(feed.address);
+        expect(await oracle.quoteTokenName()).to.equal(quoteTokenName);
+        expect(await oracle.quoteTokenAddress()).to.equal(quoteToken);
+        expect(await oracle.quoteTokenSymbol()).to.equal(quoteTokenSymbol);
+        expect(await oracle.quoteTokenDecimals()).to.equal(quoteTokenDecimals);
+        expect(await oracle.liquidityDecimals()).to.equal(0);
+    });
+});
+
+describe("VenusOracleView#getLatestObservation - special cases", function () {
+    var quoteToken;
+    var feedToken;
+    var oracle;
+    var feed;
+
+    afterEach(async function () {
+        // Reset the network to reset the time
+        const newConfig = [
+            {
+                forking: {
+                    jsonRpcUrl: hre.network.config.forking.url,
+                    blockNumber: hre.network.config.forking.blockNumber,
+                },
+            },
+        ];
+
+        await hre.network.provider.send("hardhat_reset", newConfig);
+    });
+
+    it("Works with native BNB as the feed token", async function () {
+        feedToken = NATIVE_BNB;
+        quoteToken = USDC;
+        const deployment = await createDefaultVenusOracle(feedToken, quoteToken);
+        oracle = deployment.oracle;
+        feed = deployment.feed;
+
+        const price = ethers.utils.parseUnits("3", 18);
+
+        await feed.setRoundDataNow(price);
+
+        const observation = await oracle.getLatestObservation(feedToken);
+        expect(observation.price).to.equal(price);
+    });
+
+    it("Uses 18 decimals if the feed token is invalid", async function () {
+        feedToken = ethers.constants.AddressZero;
+        quoteToken = USDC;
+        const deployment = await createDefaultVenusOracle(feedToken, quoteToken);
+        oracle = deployment.oracle;
+        feed = deployment.feed;
+
+        const price = ethers.utils.parseUnits("3", 18);
+
+        await feed.setRoundDataNow(price);
+
+        const observation = await oracle.getLatestObservation(feedToken);
+        expect(observation.price).to.equal(price);
+    });
+
+    it("Uses 18 decimals if the feed token has a bad decimals() function", async function () {
+        const badTokenFactory = await ethers.getContractFactory("Erc20InvalidDecimalFunc");
+        const feedTokenContract = await badTokenFactory.deploy();
+        await feedTokenContract.deployed();
+        feedToken = feedTokenContract.address;
+        quoteToken = USDC;
+        const deployment = await createDefaultVenusOracle(feedToken, quoteToken);
+        oracle = deployment.oracle;
+        feed = deployment.feed;
+        const price = ethers.utils.parseUnits("3", 18);
+        await feed.setRoundDataNow(price);
+        const observation = await oracle.getLatestObservation(feedToken);
+        expect(observation.price).to.equal(price);
+    });
+
+    it("Uses 18 decimals if the feed token doesn't implement a decimal func", async function () {
+        const badTokenFactory = await ethers.getContractFactory("Erc20NoDecimalFunc");
+        const feedTokenContract = await badTokenFactory.deploy();
+        await feedTokenContract.deployed();
+        feedToken = feedTokenContract.address;
+        quoteToken = USDC;
+        const deployment = await createDefaultVenusOracle(feedToken, quoteToken);
+        oracle = deployment.oracle;
+        feed = deployment.feed;
+        const price = ethers.utils.parseUnits("3", 18);
+        await feed.setRoundDataNow(price);
+        const observation = await oracle.getLatestObservation(feedToken);
+        expect(observation.price).to.equal(price);
+    });
+
+    it("Reverts if the block timestamp is too large", async function () {
+        feedToken = GRT;
+        quoteToken = USDC;
+        const deployment = await createDefaultVenusOracle(feedToken, quoteToken);
+        oracle = deployment.oracle;
+        feed = deployment.feed;
+        const price = ethers.utils.parseUnits("3", 6);
+
+        await timeAndMine.setTime(2 ** 32); // Set a timestamp that is too large
+
+        await feed.setRoundDataNow(price); // Set a timestamp that is too large
+        await expect(oracle.getLatestObservation(feedToken)).to.be.revertedWith("InvalidTimestamp");
+    });
+
+    it("Works when quote token decimals is larger than the feed decimals", async function () {
+        feedToken = GRT;
+        quoteToken = USDC;
+        const quoteTokenDecimals = 20;
+        const deployment = await createDefaultVenusOracle(feedToken, quoteToken, "VenusOracleView", {
+            quoteTokenDecimals: quoteTokenDecimals,
+        });
+        oracle = deployment.oracle;
+        feed = deployment.feed;
+
+        const price = ethers.utils.parseUnits("3", quoteTokenDecimals);
+
+        await feed.setRoundDataNow(price);
+        const observation = await oracle.getLatestObservation(feedToken);
+        expect(observation.price).to.equal(price);
+    });
+});
+
 describe("PythOracleView#getLatestObservation - special cases", function () {
     var quoteToken;
     var feedToken;
@@ -543,7 +743,29 @@ describe("PythOracleView#getLatestObservation - special cases", function () {
     });
 });
 
-function describeTests(contractName, createDefaultOracle, maxPriceBits, priceIsSigned) {
+function describeTests(contractName, createDefaultOracle, maxPriceBits, priceIsSigned, feedSupportsTimestamps) {
+    const feedTokens = [
+        {
+            name: "GRT (18 decimals)",
+            address: GRT,
+        },
+        {
+            name: "WBTC (8 decimals)",
+            address: WBTC,
+        },
+    ];
+
+    const quoteTokens = [
+        {
+            name: "USDC (6 decimals)",
+            address: USDC,
+        },
+        {
+            name: "DAI (18 decimals)",
+            address: DAI,
+        },
+    ];
+
     describe(contractName + "#canUpdate", function () {
         var quoteToken;
         var feedToken;
@@ -668,317 +890,397 @@ function describeTests(contractName, createDefaultOracle, maxPriceBits, priceIsS
     });
 
     describe(contractName + "#getLatestObservation", function () {
-        var quoteToken;
-        var feedToken;
-        var oracle;
-        var feed;
+        for (const feedToken_ of feedTokens) {
+            describe("with " + feedToken_.name + " as the feed token", function () {
+                for (const quoteToken_ of quoteTokens) {
+                    describe("With " + quoteToken_.name + " as the quote token", function () {
+                        var feedToken;
+                        var quoteToken;
+                        var oracle;
+                        var feed;
 
-        beforeEach(async function () {
-            quoteToken = USDC;
-            feedToken = GRT;
-            const deployment = await createDefaultOracle(feedToken, quoteToken);
-            oracle = deployment.oracle;
-            feed = deployment.feed;
-        });
+                        beforeEach(async function () {
+                            feedToken = feedToken_.address;
+                            quoteToken = quoteToken_.address;
+                            const deployment = await createDefaultOracle(feedToken, quoteToken);
+                            oracle = deployment.oracle;
+                            feed = deployment.feed;
+                        });
 
-        it("Reverts if the token address does not match the feed token address", async function () {
-            const token = AddressZero;
-            await expect(oracle.getLatestObservation(token)).to.be.revertedWith("UnsupportedToken");
-        });
+                        it("Reverts if the token address does not match the feed token address", async function () {
+                            const token = AddressZero;
+                            await expect(oracle.getLatestObservation(token)).to.be.revertedWith("UnsupportedToken");
+                        });
 
-        it("Reverts if the feed's timestamp is zero", async function () {
-            const token = feedToken;
-            await expect(oracle.getLatestObservation(token)).to.be.revertedWith("InvalidTimestamp");
-        });
+                        if (feedSupportsTimestamps) {
+                            it("Reverts if the feed's timestamp is zero", async function () {
+                                const token = feedToken;
+                                await expect(oracle.getLatestObservation(token)).to.be.revertedWith("InvalidTimestamp");
+                            });
 
-        it("Reverts if the feed's timestamp equals 2^32", async function () {
-            const token = feedToken;
-            const decimals = await feed.decimals();
-            const timestamp = BigNumber.from(2).pow(32);
-            await feed.setRoundData(1, ethers.utils.parseUnits("3", decimals), timestamp, timestamp, 1);
-            await expect(oracle.getLatestObservation(token)).to.be.revertedWith("InvalidTimestamp");
-        });
+                            it("Reverts if the feed's timestamp equals 2^32", async function () {
+                                const token = feedToken;
+                                const decimals = await feed.decimals();
+                                const timestamp = BigNumber.from(2).pow(32);
+                                await feed.setRoundData(
+                                    1,
+                                    ethers.utils.parseUnits("3", decimals),
+                                    timestamp,
+                                    timestamp,
+                                    1
+                                );
+                                await expect(oracle.getLatestObservation(token)).to.be.revertedWith("InvalidTimestamp");
+                            });
 
-        it("Reverts if the feed's timestamp exceeds 2^32", async function () {
-            const token = feedToken;
-            const decimals = await feed.decimals();
-            const timestamp = BigNumber.from(2).pow(32).add(1);
-            await feed.setRoundData(1, ethers.utils.parseUnits("3", decimals), timestamp, timestamp, 1);
-            await expect(oracle.getLatestObservation(token)).to.be.revertedWith("InvalidTimestamp");
-        });
+                            it("Reverts if the feed's timestamp exceeds 2^32", async function () {
+                                const token = feedToken;
+                                const decimals = await feed.decimals();
+                                const timestamp = BigNumber.from(2).pow(32).add(1);
+                                await feed.setRoundData(
+                                    1,
+                                    ethers.utils.parseUnits("3", decimals),
+                                    timestamp,
+                                    timestamp,
+                                    1
+                                );
+                                await expect(oracle.getLatestObservation(token)).to.be.revertedWith("InvalidTimestamp");
+                            });
 
-        if (priceIsSigned) {
-            it("Reverts if the answer is negative", async function () {
-                const token = feedToken;
-                const decimals = await feed.decimals();
-                await feed.setRoundDataNow(ethers.utils.parseUnits("-3", decimals));
-                await expect(oracle.getLatestObservation(token)).to.be.revertedWith("AnswerCannotBeNegative");
+                            it("The timestamp equals the feed's timestamp", async function () {
+                                const token = feedToken;
+                                const decimals = await feed.decimals();
+                                const answer = ethers.utils.parseUnits("1", decimals);
+                                const timestamp = (await currentBlockTimestamp()) - 100;
+                                await feed.setRoundData(1, answer, timestamp, timestamp, 1);
+                                const observation = await oracle.getLatestObservation(token);
+                                expect(observation.timestamp).to.equal(timestamp);
+                            });
+                        }
+
+                        if (priceIsSigned) {
+                            it("Reverts if the answer is negative", async function () {
+                                const token = feedToken;
+                                const decimals = await feed.decimals();
+                                await feed.setRoundDataNow(ethers.utils.parseUnits("-3", decimals));
+                                await expect(oracle.getLatestObservation(token)).to.be.revertedWith(
+                                    "AnswerCannotBeNegative"
+                                );
+                            });
+                        }
+
+                        // Prices stored using 112 bits, so we test this boundary
+                        if (maxPriceBits > 112) {
+                            it("Reverts if the answer equals 2^112", async function () {
+                                const token = feedToken;
+                                const answer = BigNumber.from(2).pow(112);
+                                await feed.setRoundDataNow(answer);
+                                await expect(oracle.getLatestObservation(token)).to.be.revertedWith("AnswerTooLarge");
+                            });
+
+                            it("Reverts if the answer exceeds 2^112", async function () {
+                                const token = feedToken;
+                                const answer = BigNumber.from(2).pow(112).add(1);
+                                await feed.setRoundDataNow(answer);
+                                await expect(oracle.getLatestObservation(token)).to.be.revertedWith("AnswerTooLarge");
+                            });
+                        }
+
+                        it("The price is correct when the answer is zero", async function () {
+                            const token = feedToken;
+                            const answer = BigNumber.from(0);
+                            await feed.setRoundDataNow(answer);
+                            const observation = await oracle.getLatestObservation(token);
+                            expect(observation.price).to.equal(answer);
+                        });
+
+                        it("The price is correct when the answer is one", async function () {
+                            const token = feedToken;
+                            const answer = BigNumber.from(1);
+                            await feed.setRoundDataNow(answer);
+                            const observation = await oracle.getLatestObservation(token);
+                            expect(observation.price).to.equal(answer);
+                        });
+
+                        if (maxPriceBits > 112) {
+                            it("The price is correct when the answer equals 2^112 - 1", async function () {
+                                const token = feedToken;
+                                const answer = BigNumber.from(2).pow(112).sub(1);
+                                await feed.setRoundDataNow(answer);
+                                const observation = await oracle.getLatestObservation(token);
+                                expect(observation.price).to.equal(answer);
+                            });
+                        } else {
+                            const maxPow = priceIsSigned ? maxPriceBits - 1 : maxPriceBits;
+
+                            it("The price is correct when the answer equals 2^" + maxPow + " - 1", async function () {
+                                const token = feedToken;
+                                const answer = BigNumber.from(2).pow(maxPow).sub(1);
+                                await feed.setRoundDataNow(answer);
+                                const observation = await oracle.getLatestObservation(token);
+                                expect(observation.price).to.equal(answer);
+                            });
+                        }
+
+                        it("The price is correct when the answer equals a common price (one whole quote token)", async function () {
+                            const token = feedToken;
+                            const decimals = await feed.decimals();
+                            const answer = ethers.utils.parseUnits("1", decimals);
+                            await feed.setRoundDataNow(answer);
+                            const observation = await oracle.getLatestObservation(token);
+                            expect(observation.price).to.equal(answer);
+                        });
+
+                        it("Token liquidity and quote token liquidity are zero", async function () {
+                            const token = feedToken;
+                            const decimals = await feed.decimals();
+                            const answer = ethers.utils.parseUnits("1", decimals);
+                            await feed.setRoundDataNow(answer);
+                            const observation = await oracle.getLatestObservation(token);
+                            expect(observation.tokenLiquidity).to.equal(0);
+                            expect(observation.quoteTokenLiquidity).to.equal(0);
+                        });
+                    });
+                }
             });
         }
-
-        // Prices stored using 112 bits, so we test this boundary
-        if (maxPriceBits > 112) {
-            it("Reverts if the answer equals 2^112", async function () {
-                const token = feedToken;
-                const answer = BigNumber.from(2).pow(112);
-                await feed.setRoundDataNow(answer);
-                await expect(oracle.getLatestObservation(token)).to.be.revertedWith("AnswerTooLarge");
-            });
-
-            it("Reverts if the answer exceeds 2^112", async function () {
-                const token = feedToken;
-                const answer = BigNumber.from(2).pow(112).add(1);
-                await feed.setRoundDataNow(answer);
-                await expect(oracle.getLatestObservation(token)).to.be.revertedWith("AnswerTooLarge");
-            });
-        }
-
-        it("The price is correct when the answer is zero", async function () {
-            const token = feedToken;
-            const answer = BigNumber.from(0);
-            await feed.setRoundDataNow(answer);
-            const observation = await oracle.getLatestObservation(token);
-            expect(observation.price).to.equal(answer);
-        });
-
-        it("The price is correct when the answer is one", async function () {
-            const token = feedToken;
-            const answer = BigNumber.from(1);
-            await feed.setRoundDataNow(answer);
-            const observation = await oracle.getLatestObservation(token);
-            expect(observation.price).to.equal(answer);
-        });
-
-        if (maxPriceBits > 112) {
-            it("The price is correct when the answer equals 2^112 - 1", async function () {
-                const token = feedToken;
-                const answer = BigNumber.from(2).pow(112).sub(1);
-                await feed.setRoundDataNow(answer);
-                const observation = await oracle.getLatestObservation(token);
-                expect(observation.price).to.equal(answer);
-            });
-        } else {
-            const maxPow = priceIsSigned ? maxPriceBits - 1 : maxPriceBits;
-
-            it("The price is correct when the answer equals 2^" + maxPow + " - 1", async function () {
-                const token = feedToken;
-                const answer = BigNumber.from(2).pow(maxPow).sub(1);
-                await feed.setRoundDataNow(answer);
-                const observation = await oracle.getLatestObservation(token);
-                expect(observation.price).to.equal(answer);
-            });
-        }
-
-        it("The price is correct when the answer equals a common price (one whole quote token)", async function () {
-            const token = feedToken;
-            const decimals = await feed.decimals();
-            const answer = ethers.utils.parseUnits("1", decimals);
-            await feed.setRoundDataNow(answer);
-            const observation = await oracle.getLatestObservation(token);
-            expect(observation.price).to.equal(answer);
-        });
-
-        it("The timestamp equals the feed's timestamp", async function () {
-            const token = feedToken;
-            const decimals = await feed.decimals();
-            const answer = ethers.utils.parseUnits("1", decimals);
-            const timestamp = (await currentBlockTimestamp()) - 100;
-            await feed.setRoundData(1, answer, timestamp, timestamp, 1);
-            const observation = await oracle.getLatestObservation(token);
-            expect(observation.timestamp).to.equal(timestamp);
-        });
-
-        it("Token liquidity and quote token liquidity are zero", async function () {
-            const token = feedToken;
-            const decimals = await feed.decimals();
-            const answer = ethers.utils.parseUnits("1", decimals);
-            await feed.setRoundDataNow(answer);
-            const observation = await oracle.getLatestObservation(token);
-            expect(observation.tokenLiquidity).to.equal(0);
-            expect(observation.quoteTokenLiquidity).to.equal(0);
-        });
     });
 
     describe(contractName + "#consultPrice(token, maxAge = 0)", function () {
-        var quoteToken;
-        var feedToken;
-        var oracle;
-        var feed;
+        for (const feedToken_ of feedTokens) {
+            describe("with " + feedToken_.name + " as the feed token", function () {
+                for (const quoteToken_ of quoteTokens) {
+                    describe("With " + quoteToken_.name + " as the quote token", function () {
+                        var quoteToken;
+                        var feedToken;
+                        var oracle;
+                        var feed;
 
-        beforeEach(async function () {
-            quoteToken = USDC;
-            feedToken = GRT;
-            const deployment = await createDefaultOracle(feedToken, quoteToken);
-            oracle = deployment.oracle;
-            feed = deployment.feed;
-        });
+                        beforeEach(async function () {
+                            quoteToken = USDC;
+                            feedToken = GRT;
+                            const deployment = await createDefaultOracle(feedToken, quoteToken);
+                            oracle = deployment.oracle;
+                            feed = deployment.feed;
+                        });
 
-        it("Returns the feed's current price", async function () {
-            const decimals = await feed.decimals();
-            const answer = ethers.utils.parseUnits("3", decimals);
-            await feed.setRoundDataNow(answer);
+                        it("Returns the feed's current price", async function () {
+                            const decimals = await feed.decimals();
+                            const answer = ethers.utils.parseUnits("3", decimals);
+                            await feed.setRoundDataNow(answer);
 
-            expect(await oracle["consultPrice(address,uint256)"](feedToken, 0)).to.equal(answer);
-        });
+                            expect(await oracle["consultPrice(address,uint256)"](feedToken, 0)).to.equal(answer);
+                        });
 
-        it("Returns one whole quote token if the token is the quote token", async function () {
-            const decimals = await feed.decimals();
+                        it("Returns one whole quote token if the token is the quote token", async function () {
+                            const decimals = await feed.decimals();
 
-            expect(await oracle["consultPrice(address,uint256)"](quoteToken, 0)).to.equal(
-                ethers.utils.parseUnits("1", decimals)
-            );
-        });
+                            expect(await oracle["consultPrice(address,uint256)"](quoteToken, 0)).to.equal(
+                                ethers.utils.parseUnits("1", decimals)
+                            );
+                        });
 
-        it("Reverts if the token does not match the feed token", async function () {
-            const token = DAI;
-            await expect(oracle["consultPrice(address,uint256)"](token, 0)).to.be.revertedWith("UnsupportedToken");
-        });
+                        it("Reverts if the token does not match the feed token", async function () {
+                            const token = DAI;
+                            await expect(oracle["consultPrice(address,uint256)"](token, 0)).to.be.revertedWith(
+                                "UnsupportedToken"
+                            );
+                        });
 
-        it("Reverts if the feed's timestamp is zero", async function () {
-            const decimals = await feed.decimals();
-            const answer = ethers.utils.parseUnits("3", decimals);
-            await feed.setRoundData(1, answer, 0, 0, 1);
+                        if (feedSupportsTimestamps) {
+                            it("Reverts if the feed's timestamp is zero", async function () {
+                                const decimals = await feed.decimals();
+                                const answer = ethers.utils.parseUnits("3", decimals);
+                                await feed.setRoundData(1, answer, 0, 0, 1);
 
-            await expect(oracle["consultPrice(address,uint256)"](feedToken, 0)).to.be.revertedWith("InvalidTimestamp");
-        });
+                                await expect(oracle["consultPrice(address,uint256)"](feedToken, 0)).to.be.revertedWith(
+                                    "InvalidTimestamp"
+                                );
+                            });
+                        }
+                    });
+                }
+            });
+        }
     });
 
     describe(contractName + "#consultLiquidity(token, maxAge = 0)", function () {
-        var quoteToken;
-        var feedToken;
-        var oracle;
-        var feed;
+        for (const feedToken_ of feedTokens) {
+            describe("with " + feedToken_.name + " as the feed token", function () {
+                for (const quoteToken_ of quoteTokens) {
+                    describe("With " + quoteToken_.name + " as the quote token", function () {
+                        var quoteToken;
+                        var feedToken;
+                        var oracle;
+                        var feed;
 
-        beforeEach(async function () {
-            quoteToken = USDC;
-            feedToken = GRT;
-            const deployment = await createDefaultOracle(feedToken, quoteToken);
-            oracle = deployment.oracle;
-            feed = deployment.feed;
-        });
+                        beforeEach(async function () {
+                            quoteToken = USDC;
+                            feedToken = GRT;
+                            const deployment = await createDefaultOracle(feedToken, quoteToken);
+                            oracle = deployment.oracle;
+                            feed = deployment.feed;
+                        });
 
-        it("Returns zero liquidity for the token and quote token, when the feed has data that describes the token", async function () {
-            const decimals = await feed.decimals();
-            const answer = ethers.utils.parseUnits("3", decimals);
-            await feed.setRoundDataNow(answer);
+                        it("Returns zero liquidity for the token and quote token, when the feed has data that describes the token", async function () {
+                            const decimals = await feed.decimals();
+                            const answer = ethers.utils.parseUnits("3", decimals);
+                            await feed.setRoundDataNow(answer);
 
-            const [tokenLiquidity, quoteTokenLiquidity] = await oracle["consultLiquidity(address,uint256)"](
-                feedToken,
-                0
-            );
-            expect(tokenLiquidity).to.equal(ethers.constants.Zero);
-            expect(quoteTokenLiquidity).to.equal(ethers.constants.Zero);
-        });
+                            const [tokenLiquidity, quoteTokenLiquidity] = await oracle[
+                                "consultLiquidity(address,uint256)"
+                            ](feedToken, 0);
+                            expect(tokenLiquidity).to.equal(ethers.constants.Zero);
+                            expect(quoteTokenLiquidity).to.equal(ethers.constants.Zero);
+                        });
 
-        it("Returns zero liquidity for the token and quote token, when the token is the quote token", async function () {
-            const [tokenLiquidity, quoteTokenLiquidity] = await oracle["consultLiquidity(address,uint256)"](
-                quoteToken,
-                0
-            );
-            expect(tokenLiquidity).to.equal(ethers.constants.Zero);
-            expect(quoteTokenLiquidity).to.equal(ethers.constants.Zero);
-        });
+                        it("Returns zero liquidity for the token and quote token, when the token is the quote token", async function () {
+                            const [tokenLiquidity, quoteTokenLiquidity] = await oracle[
+                                "consultLiquidity(address,uint256)"
+                            ](quoteToken, 0);
+                            expect(tokenLiquidity).to.equal(ethers.constants.Zero);
+                            expect(quoteTokenLiquidity).to.equal(ethers.constants.Zero);
+                        });
 
-        it("Reverts if the token does not match the feed token", async function () {
-            const token = DAI;
-            await expect(oracle["consultLiquidity(address,uint256)"](token, 0)).to.be.revertedWith("UnsupportedToken");
-        });
+                        it("Reverts if the token does not match the feed token", async function () {
+                            const token = DAI;
+                            await expect(oracle["consultLiquidity(address,uint256)"](token, 0)).to.be.revertedWith(
+                                "UnsupportedToken"
+                            );
+                        });
 
-        it("Reverts if the feed's timestamp is zero", async function () {
-            const decimals = await feed.decimals();
-            const answer = ethers.utils.parseUnits("3", decimals);
-            await feed.setRoundData(1, answer, 0, 0, 1);
+                        if (feedSupportsTimestamps) {
+                            it("Reverts if the feed's timestamp is zero", async function () {
+                                const decimals = await feed.decimals();
+                                const answer = ethers.utils.parseUnits("3", decimals);
+                                await feed.setRoundData(1, answer, 0, 0, 1);
 
-            await expect(oracle["consultLiquidity(address,uint256)"](feedToken, 0)).to.be.revertedWith(
-                "InvalidTimestamp"
-            );
-        });
+                                await expect(
+                                    oracle["consultLiquidity(address,uint256)"](feedToken, 0)
+                                ).to.be.revertedWith("InvalidTimestamp");
+                            });
+                        }
+                    });
+                }
+            });
+        }
     });
 
     describe(contractName + "#consultPrice(token)", function () {
-        var quoteToken;
-        var feedToken;
-        var oracle;
-        var feed;
+        for (const feedToken_ of feedTokens) {
+            describe("with " + feedToken_.name + " as the feed token", function () {
+                for (const quoteToken_ of quoteTokens) {
+                    describe("With " + quoteToken_.name + " as the quote token", function () {
+                        var quoteToken;
+                        var feedToken;
+                        var oracle;
+                        var feed;
 
-        beforeEach(async function () {
-            quoteToken = USDC;
-            feedToken = GRT;
-            const deployment = await createDefaultOracle(feedToken, quoteToken);
-            oracle = deployment.oracle;
-            feed = deployment.feed;
-        });
+                        beforeEach(async function () {
+                            quoteToken = USDC;
+                            feedToken = GRT;
+                            const deployment = await createDefaultOracle(feedToken, quoteToken);
+                            oracle = deployment.oracle;
+                            feed = deployment.feed;
+                        });
 
-        it("Returns the feed's current price", async function () {
-            const decimals = await feed.decimals();
-            const answer = ethers.utils.parseUnits("3", decimals);
-            await feed.setRoundDataNow(answer);
+                        it("Returns the feed's current price", async function () {
+                            const decimals = await feed.decimals();
+                            const answer = ethers.utils.parseUnits("3", decimals);
+                            await feed.setRoundDataNow(answer);
 
-            expect(await oracle["consultPrice(address)"](feedToken)).to.equal(answer);
-        });
+                            expect(await oracle["consultPrice(address)"](feedToken)).to.equal(answer);
+                        });
 
-        it("Returns one whole quote token if the token is the quote token", async function () {
-            const decimals = await feed.decimals();
+                        it("Returns one whole quote token if the token is the quote token", async function () {
+                            const decimals = await feed.decimals();
 
-            expect(await oracle["consultPrice(address)"](quoteToken)).to.equal(ethers.utils.parseUnits("1", decimals));
-        });
+                            expect(await oracle["consultPrice(address)"](quoteToken)).to.equal(
+                                ethers.utils.parseUnits("1", decimals)
+                            );
+                        });
 
-        it("Reverts if the token does not match the feed token", async function () {
-            const token = DAI;
-            await expect(oracle["consultPrice(address)"](token)).to.be.revertedWith("UnsupportedToken");
-        });
+                        it("Reverts if the token does not match the feed token", async function () {
+                            const token = DAI;
+                            await expect(oracle["consultPrice(address)"](token)).to.be.revertedWith("UnsupportedToken");
+                        });
 
-        it("Reverts if the feed's timestamp is zero", async function () {
-            const decimals = await feed.decimals();
-            const answer = ethers.utils.parseUnits("3", decimals);
-            await feed.setRoundData(1, answer, 0, 0, 1);
+                        if (feedSupportsTimestamps) {
+                            it("Reverts if the feed's timestamp is zero", async function () {
+                                const decimals = await feed.decimals();
+                                const answer = ethers.utils.parseUnits("3", decimals);
+                                await feed.setRoundData(1, answer, 0, 0, 1);
 
-            await expect(oracle["consultPrice(address)"](feedToken)).to.be.revertedWith("InvalidTimestamp");
-        });
+                                await expect(oracle["consultPrice(address)"](feedToken)).to.be.revertedWith(
+                                    "InvalidTimestamp"
+                                );
+                            });
+                        }
+                    });
+                }
+            });
+        }
     });
 
     describe(contractName + "#consultLiquidity(token)", function () {
-        var quoteToken;
-        var feedToken;
-        var oracle;
-        var feed;
+        for (const feedToken_ of feedTokens) {
+            describe("with " + feedToken_.name + " as the feed token", function () {
+                for (const quoteToken_ of quoteTokens) {
+                    describe("With " + quoteToken_.name + " as the quote token", function () {
+                        var quoteToken;
+                        var feedToken;
+                        var oracle;
+                        var feed;
 
-        beforeEach(async function () {
-            quoteToken = USDC;
-            feedToken = GRT;
-            const deployment = await createDefaultOracle(feedToken, quoteToken);
-            oracle = deployment.oracle;
-            feed = deployment.feed;
-        });
+                        beforeEach(async function () {
+                            quoteToken = USDC;
+                            feedToken = GRT;
+                            const deployment = await createDefaultOracle(feedToken, quoteToken);
+                            oracle = deployment.oracle;
+                            feed = deployment.feed;
+                        });
 
-        it("Returns zero liquidity for the token and quote token, when the feed has data that describes the token", async function () {
-            const decimals = await feed.decimals();
-            const answer = ethers.utils.parseUnits("3", decimals);
-            await feed.setRoundDataNow(answer);
+                        it("Returns zero liquidity for the token and quote token, when the feed has data that describes the token", async function () {
+                            const decimals = await feed.decimals();
+                            const answer = ethers.utils.parseUnits("3", decimals);
+                            await feed.setRoundDataNow(answer);
 
-            const [tokenLiquidity, quoteTokenLiquidity] = await oracle["consultLiquidity(address)"](feedToken);
-            expect(tokenLiquidity).to.equal(ethers.constants.Zero);
-            expect(quoteTokenLiquidity).to.equal(ethers.constants.Zero);
-        });
+                            const [tokenLiquidity, quoteTokenLiquidity] = await oracle["consultLiquidity(address)"](
+                                feedToken
+                            );
+                            expect(tokenLiquidity).to.equal(ethers.constants.Zero);
+                            expect(quoteTokenLiquidity).to.equal(ethers.constants.Zero);
+                        });
 
-        it("Returns zero liquidity for the token and quote token, when the token is the quote token", async function () {
-            const [tokenLiquidity, quoteTokenLiquidity] = await oracle["consultLiquidity(address)"](quoteToken);
-            expect(tokenLiquidity).to.equal(ethers.constants.Zero);
-            expect(quoteTokenLiquidity).to.equal(ethers.constants.Zero);
-        });
+                        it("Returns zero liquidity for the token and quote token, when the token is the quote token", async function () {
+                            const [tokenLiquidity, quoteTokenLiquidity] = await oracle["consultLiquidity(address)"](
+                                quoteToken
+                            );
+                            expect(tokenLiquidity).to.equal(ethers.constants.Zero);
+                            expect(quoteTokenLiquidity).to.equal(ethers.constants.Zero);
+                        });
 
-        it("Reverts if the token does not match the feed token", async function () {
-            const token = DAI;
-            await expect(oracle["consultLiquidity(address)"](token)).to.be.revertedWith("UnsupportedToken");
-        });
+                        it("Reverts if the token does not match the feed token", async function () {
+                            const token = DAI;
+                            await expect(oracle["consultLiquidity(address)"](token)).to.be.revertedWith(
+                                "UnsupportedToken"
+                            );
+                        });
 
-        it("Reverts if the feed's timestamp is zero", async function () {
-            const decimals = await feed.decimals();
-            const answer = ethers.utils.parseUnits("3", decimals);
-            await feed.setRoundData(1, answer, 0, 0, 1);
+                        if (feedSupportsTimestamps) {
+                            it("Reverts if the feed's timestamp is zero", async function () {
+                                const decimals = await feed.decimals();
+                                const answer = ethers.utils.parseUnits("3", decimals);
+                                await feed.setRoundData(1, answer, 0, 0, 1);
 
-            await expect(oracle["consultLiquidity(address)"](feedToken)).to.be.revertedWith("InvalidTimestamp");
-        });
+                                await expect(oracle["consultLiquidity(address)"](feedToken)).to.be.revertedWith(
+                                    "InvalidTimestamp"
+                                );
+                            });
+                        }
+                    });
+                }
+            });
+        }
     });
 
     describe(contractName + "#supportsInterface", function () {
@@ -1019,6 +1321,7 @@ function describeTests(contractName, createDefaultOracle, maxPriceBits, priceIsS
     });
 }
 
-describeTests("ChainlinkOracleView", createDefaultChainlinkOracle, 256, true);
-describeTests("PythOracleView", createDefaultPythOracle, 64, true);
-describeTests("DiaOracleView", createDefaultDiaOracle, 128, false);
+describeTests("ChainlinkOracleView", createDefaultChainlinkOracle, 256, true, true);
+describeTests("PythOracleView", createDefaultPythOracle, 64, true, true);
+describeTests("DiaOracleView", createDefaultDiaOracle, 128, false, true);
+describeTests("VenusOracleView", createDefaultVenusOracle, 256, false, false);

--- a/test/price-accumulator/adrastia-price-accumulator.js
+++ b/test/price-accumulator/adrastia-price-accumulator.js
@@ -377,7 +377,7 @@ describe("AdrastiaPriceAccumulator#consultPrice(token,maxAge=0)", function () {
         const token = GRT;
 
         // Set the price
-        await deployment.oracle.stubSetObservationNow(token, price, 3, 5);
+        await deployment.oracle.stubSetInstantRates(token, price, 3, 5);
 
         expect(await deployment.accumulator["consultPrice(address,uint256)"](token, 0)).to.equal(price);
     });

--- a/test/price-accumulator/static-price-accumulator.js
+++ b/test/price-accumulator/static-price-accumulator.js
@@ -216,17 +216,23 @@ describe("StaticPriceAccumulator#getLastAccumulation", function () {
 
     it("Returns a valid accumulation for the zero address", async function () {
         const accumulation = [BigNumber.from(0), await currentBlockTimestamp()];
-        expect(await accumulator.getLastAccumulation(AddressZero)).to.deep.eq(accumulation);
+        const [acc, timestamp] = await accumulator.getLastAccumulation(AddressZero);
+        expect(acc).to.deep.eq(accumulation[0]);
+        expect(timestamp).to.equal(accumulation[1]);
     });
 
     it("Returns a valid accumulation for the quote token", async function () {
         const accumulation = [BigNumber.from(0), await currentBlockTimestamp()];
-        expect(await accumulator.getLastAccumulation(USDC)).to.deep.eq(accumulation);
+        const [acc, timestamp] = await accumulator.getLastAccumulation(USDC);
+        expect(acc).to.deep.eq(accumulation[0]);
+        expect(timestamp).to.equal(accumulation[1]);
     });
 
     it("Returns a valid accumulation for a valid token", async function () {
         const accumulation = [BigNumber.from(0), await currentBlockTimestamp()];
-        expect(await accumulator.getLastAccumulation(GRT)).to.deep.eq(accumulation);
+        const [acc, timestamp] = await accumulator.getLastAccumulation(GRT);
+        expect(acc).to.deep.eq(accumulation[0]);
+        expect(timestamp).to.equal(accumulation[1]);
     });
 });
 
@@ -244,17 +250,23 @@ describe("StaticPriceAccumulator#getCurrentAccumulation", function () {
 
     it("Returns a valid accumulation for the zero address", async function () {
         const accumulation = [BigNumber.from(0), await currentBlockTimestamp()];
-        expect(await accumulator.getCurrentAccumulation(AddressZero)).to.deep.eq(accumulation);
+        const [acc, timestamp] = await accumulator.getCurrentAccumulation(AddressZero);
+        expect(acc).to.deep.eq(accumulation[0]);
+        expect(timestamp).to.equal(accumulation[1]);
     });
 
     it("Returns a valid accumulation for the quote token", async function () {
         const accumulation = [BigNumber.from(0), await currentBlockTimestamp()];
-        expect(await accumulator.getCurrentAccumulation(USDC)).to.deep.eq(accumulation);
+        const [acc, timestamp] = await accumulator.getCurrentAccumulation(USDC);
+        expect(acc).to.deep.eq(accumulation[0]);
+        expect(timestamp).to.equal(accumulation[1]);
     });
 
     it("Returns a valid accumulation for a valid token", async function () {
         const accumulation = [BigNumber.from(0), await currentBlockTimestamp()];
-        expect(await accumulator.getCurrentAccumulation(GRT)).to.deep.eq(accumulation);
+        const [acc, timestamp] = await accumulator.getCurrentAccumulation(GRT);
+        expect(acc).to.deep.eq(accumulation[0]);
+        expect(timestamp).to.equal(accumulation[1]);
     });
 });
 

--- a/test/strategies/aggregation/aggregation-strategy.js
+++ b/test/strategies/aggregation/aggregation-strategy.js
@@ -1,6 +1,7 @@
 const { BigNumber } = require("ethers");
 const { expect } = require("chai");
 const { ethers, timeAndMine, network } = require("hardhat");
+const forkingConfig = require("../../../forking").default;
 
 const AddressZero = ethers.constants.AddressZero;
 
@@ -467,7 +468,17 @@ function testAggregationStrategy(contractName, deployFunction, aggregateObservat
                         });
 
                         after(async function () {
-                            await network.provider.send("hardhat_reset");
+                            // Reset the network to reset the time
+                            const newConfig = [
+                                {
+                                    forking: {
+                                        jsonRpcUrl: hre.network.config.forking.url,
+                                        blockNumber: hre.network.config.forking.blockNumber,
+                                    },
+                                },
+                            ];
+
+                            await hre.network.provider.send("hardhat_reset", newConfig);
                         });
 
                         it("Reverts when using a single observation with a large timestamp", async function () {

--- a/test/strategies/aggregation/aggregation-strategy.js
+++ b/test/strategies/aggregation/aggregation-strategy.js
@@ -1,12 +1,34 @@
 const { BigNumber } = require("ethers");
 const { expect } = require("chai");
-const { ethers } = require("hardhat");
+const { ethers, timeAndMine, network } = require("hardhat");
 
 const AddressZero = ethers.constants.AddressZero;
 
 const MAX_UINT112 = BigNumber.from(2).pow(112).sub(1);
 
 const MAX_BITS = 112;
+
+const TIMESTAMP_STRATEGY_THISBLOCK = 0;
+const TIMESTAMP_STRATEGY_EARLIESTOBSERVATION = 1;
+const TIMESTAMP_STRATEGY_LATESTOBSERVATION = 2;
+const TIMESTAMP_STRATEGY_FIRSTOBSERVATION = 3;
+const TIMESTAMP_STRATEGY_LASTOBSERVATION = 4;
+
+const TIMESTAMP_STRATEGIES = [
+    TIMESTAMP_STRATEGY_THISBLOCK,
+    TIMESTAMP_STRATEGY_EARLIESTOBSERVATION,
+    TIMESTAMP_STRATEGY_LATESTOBSERVATION,
+    TIMESTAMP_STRATEGY_FIRSTOBSERVATION,
+    TIMESTAMP_STRATEGY_LASTOBSERVATION,
+];
+
+const TIMESTAMP_STRATEGY_NAMES = [
+    "ThisBlock",
+    "EarliestObservation",
+    "LatestObservation",
+    "FirstObservation",
+    "LastObservation",
+];
 
 async function currentBlockTimestamp() {
     const currentBlockNumber = await ethers.provider.getBlockNumber();
@@ -47,7 +69,7 @@ describe("AbstractAggregator#prepareResult", function () {
 
     beforeEach(async function () {
         const aggregatorFactory = await ethers.getContractFactory("AggregatorStub");
-        aggregator = await aggregatorFactory.deploy();
+        aggregator = await aggregatorFactory.deploy(TIMESTAMP_STRATEGY_THISBLOCK);
     });
 
     it("Should revert if the price exceeds the maximum value", async function () {
@@ -55,182 +77,500 @@ describe("AbstractAggregator#prepareResult", function () {
         const tokenLiquidity = BigNumber.from(1);
         const quoteTokenLiquidity = BigNumber.from(1);
 
-        await aggregator.stubSetObservation(price, tokenLiquidity, quoteTokenLiquidity);
+        await aggregator.stubSetObservation(price, tokenLiquidity, quoteTokenLiquidity, 1);
 
         await expect(aggregator.aggregateObservations(AddressZero, [], 0, 0)).to.be.revertedWith("PriceTooHigh");
     });
 });
 
+describe("AbstractAggregator#validateTimestampStrategy", function () {
+    var aggregator;
+
+    beforeEach(async function () {
+        const aggregatorFactory = await ethers.getContractFactory("AggregatorStub");
+        aggregator = await aggregatorFactory.deploy(TIMESTAMP_STRATEGY_THISBLOCK);
+    });
+
+    it("Should revert if the timestamp strategy is not supported", async function () {
+        const invalidTimestampStrategy = TIMESTAMP_STRATEGIES[TIMESTAMP_STRATEGIES.length - 1] + 1; // Invalid strategy
+
+        // Either panic (at the time of writing), or revert with a specific error if an additional validation strategy
+        // is added to the enum in the future.
+        await expect(aggregator.stubValidateTimestampStrategy(invalidTimestampStrategy)).to.be.reverted;
+    });
+
+    it("Should not revert when using 'this block' timestamp strategy", async function () {
+        await expect(aggregator.stubValidateTimestampStrategy(TIMESTAMP_STRATEGY_THISBLOCK)).to.not.be.reverted;
+    });
+
+    it("Should not revert when using 'earliest observation' timestamp strategy", async function () {
+        await expect(aggregator.stubValidateTimestampStrategy(TIMESTAMP_STRATEGY_EARLIESTOBSERVATION)).to.not.be
+            .reverted;
+    });
+
+    it("Should not revert when using 'latest observation' timestamp strategy", async function () {
+        await expect(aggregator.stubValidateTimestampStrategy(TIMESTAMP_STRATEGY_LATESTOBSERVATION)).to.not.be.reverted;
+    });
+
+    it("Should not revert when using 'first observation' timestamp strategy", async function () {
+        await expect(aggregator.stubValidateTimestampStrategy(TIMESTAMP_STRATEGY_FIRSTOBSERVATION)).to.not.be.reverted;
+    });
+
+    it("Should not revert when using 'last observation' timestamp strategy", async function () {
+        await expect(aggregator.stubValidateTimestampStrategy(TIMESTAMP_STRATEGY_LASTOBSERVATION)).to.not.be.reverted;
+    });
+});
+
+describe("AbstractAggregator#calculateFinalTimestamp", function () {
+    describe("Using 'this block' timestamp strategy", function () {
+        let aggregator;
+
+        beforeEach(async function () {
+            const aggregatorFactory = await ethers.getContractFactory("AggregatorStub");
+            aggregator = await aggregatorFactory.deploy(TIMESTAMP_STRATEGY_THISBLOCK);
+        });
+
+        it("Should revert if no timestamps are provided", async function () {
+            await expect(aggregator.stubCalculateFinalTimestamp([])).to.be.revertedWith("NoTimestampsProvided");
+        });
+
+        it("Should return the current block timestamp", async function () {
+            const providedTimestamp = 1;
+            const currentTimestamp = await currentBlockTimestamp();
+            const finalTimestamp = await aggregator.stubCalculateFinalTimestamp([providedTimestamp]);
+
+            expect(finalTimestamp).to.equal(currentTimestamp);
+
+            // Sanity check
+            expect(currentBlockTimestamp).to.not.equal(providedTimestamp);
+        });
+    });
+
+    describe("Using 'earliest observation' timestamp strategy", function () {
+        let aggregator;
+
+        beforeEach(async function () {
+            const aggregatorFactory = await ethers.getContractFactory("AggregatorStub");
+            aggregator = await aggregatorFactory.deploy(TIMESTAMP_STRATEGY_EARLIESTOBSERVATION);
+        });
+
+        it("Should revert if no timestamps are provided", async function () {
+            await expect(aggregator.stubCalculateFinalTimestamp([])).to.be.revertedWith("NoTimestampsProvided");
+        });
+
+        it("Should return the earliest timestamp", async function () {
+            const timestamps = [1, 2, 3];
+            const finalTimestamp = await aggregator.stubCalculateFinalTimestamp(timestamps);
+
+            expect(finalTimestamp).to.equal(1);
+
+            const timestamps2 = [3, 2, 1];
+            const finalTimestamp2 = await aggregator.stubCalculateFinalTimestamp(timestamps2);
+
+            expect(finalTimestamp2).to.equal(1);
+
+            const timestamps3 = [3, 1];
+            const finalTimestamp3 = await aggregator.stubCalculateFinalTimestamp(timestamps3);
+
+            expect(finalTimestamp3).to.equal(1);
+
+            const timestamps4 = [1, 3];
+            const finalTimestamp4 = await aggregator.stubCalculateFinalTimestamp(timestamps4);
+
+            expect(finalTimestamp4).to.equal(1);
+
+            const timestamps5 = [2];
+            const finalTimestamp5 = await aggregator.stubCalculateFinalTimestamp(timestamps5);
+
+            expect(finalTimestamp5).to.equal(2);
+        });
+    });
+
+    describe("Using 'latest observation' timestamp strategy", function () {
+        let aggregator;
+
+        beforeEach(async function () {
+            const aggregatorFactory = await ethers.getContractFactory("AggregatorStub");
+            aggregator = await aggregatorFactory.deploy(TIMESTAMP_STRATEGY_LATESTOBSERVATION);
+        });
+
+        it("Should revert if no timestamps are provided", async function () {
+            await expect(aggregator.stubCalculateFinalTimestamp([])).to.be.revertedWith("NoTimestampsProvided");
+        });
+
+        it("Should return the latest timestamp", async function () {
+            const timestamps = [1, 2, 3];
+            const finalTimestamp = await aggregator.stubCalculateFinalTimestamp(timestamps);
+
+            expect(finalTimestamp).to.equal(3);
+
+            const timestamps2 = [3, 2, 1];
+            const finalTimestamp2 = await aggregator.stubCalculateFinalTimestamp(timestamps2);
+
+            expect(finalTimestamp2).to.equal(3);
+
+            const timestamps3 = [3, 1];
+            const finalTimestamp3 = await aggregator.stubCalculateFinalTimestamp(timestamps3);
+
+            expect(finalTimestamp3).to.equal(3);
+
+            const timestamps4 = [1, 3];
+            const finalTimestamp4 = await aggregator.stubCalculateFinalTimestamp(timestamps4);
+
+            expect(finalTimestamp4).to.equal(3);
+
+            const timestamps5 = [2];
+            const finalTimestamp5 = await aggregator.stubCalculateFinalTimestamp(timestamps5);
+
+            expect(finalTimestamp5).to.equal(2);
+        });
+    });
+
+    describe("Using 'first observation' timestamp strategy", function () {
+        let aggregator;
+
+        beforeEach(async function () {
+            const aggregatorFactory = await ethers.getContractFactory("AggregatorStub");
+            aggregator = await aggregatorFactory.deploy(TIMESTAMP_STRATEGY_FIRSTOBSERVATION);
+        });
+
+        it("Should revert if no timestamps are provided", async function () {
+            await expect(aggregator.stubCalculateFinalTimestamp([])).to.be.revertedWith("NoTimestampsProvided");
+        });
+
+        it("Should return the first timestamp", async function () {
+            const timestamps = [1, 2, 3];
+            const finalTimestamp = await aggregator.stubCalculateFinalTimestamp(timestamps);
+
+            expect(finalTimestamp).to.equal(1);
+
+            const timestamps2 = [3, 2, 1];
+            const finalTimestamp2 = await aggregator.stubCalculateFinalTimestamp(timestamps2);
+
+            expect(finalTimestamp2).to.equal(3);
+
+            const timestamps3 = [3, 1];
+            const finalTimestamp3 = await aggregator.stubCalculateFinalTimestamp(timestamps3);
+
+            expect(finalTimestamp3).to.equal(3);
+
+            const timestamps4 = [1, 3];
+            const finalTimestamp4 = await aggregator.stubCalculateFinalTimestamp(timestamps4);
+
+            expect(finalTimestamp4).to.equal(1);
+
+            const timestamps5 = [2];
+            const finalTimestamp5 = await aggregator.stubCalculateFinalTimestamp(timestamps5);
+
+            expect(finalTimestamp5).to.equal(2);
+        });
+    });
+
+    describe("Using 'last observation' timestamp strategy", function () {
+        let aggregator;
+
+        beforeEach(async function () {
+            const aggregatorFactory = await ethers.getContractFactory("AggregatorStub");
+            aggregator = await aggregatorFactory.deploy(TIMESTAMP_STRATEGY_LASTOBSERVATION);
+        });
+
+        it("Should revert if no timestamps are provided", async function () {
+            await expect(aggregator.stubCalculateFinalTimestamp([])).to.be.revertedWith("NoTimestampsProvided");
+        });
+
+        it("Should return the last timestamp", async function () {
+            const timestamps = [1, 2, 3];
+            const finalTimestamp = await aggregator.stubCalculateFinalTimestamp(timestamps);
+            expect(finalTimestamp).to.equal(3);
+
+            const timestamps2 = [3, 2, 1];
+            const finalTimestamp2 = await aggregator.stubCalculateFinalTimestamp(timestamps2);
+            expect(finalTimestamp2).to.equal(1);
+
+            const timestamps3 = [3, 1];
+            const finalTimestamp3 = await aggregator.stubCalculateFinalTimestamp(timestamps3);
+            expect(finalTimestamp3).to.equal(1);
+
+            const timestamps4 = [1, 3];
+            const finalTimestamp4 = await aggregator.stubCalculateFinalTimestamp(timestamps4);
+            expect(finalTimestamp4).to.equal(3);
+
+            const timestamps5 = [2];
+            const finalTimestamp5 = await aggregator.stubCalculateFinalTimestamp(timestamps5);
+            expect(finalTimestamp5).to.equal(2);
+        });
+    });
+});
+
+function bigNumberMin(arr) {
+    if (arr.length === 0) {
+        throw new Error("Array is empty");
+    }
+
+    return arr.reduce((min, current) => (current.lt(min) ? current : min), arr[0]);
+}
+
+function bigNumberMax(arr) {
+    if (arr.length === 0) {
+        throw new Error("Array is empty");
+    }
+
+    return arr.reduce((max, current) => (current.gt(max) ? current : max), arr[0]);
+}
+
 function testAggregationStrategy(contractName, deployFunction, aggregateObservations) {
     describe(contractName, function () {
         var aggregator;
+        var timestampStrategy;
 
         beforeEach(async function () {
-            aggregator = await deployFunction();
+            timestampStrategy = TIMESTAMP_STRATEGY_THISBLOCK; // Default timestamp strategy
+            aggregator = await deployFunction(timestampStrategy);
         });
 
-        const lengths = [1, 2, 3, 4, 5, 8, 9, 16, 17];
-        const nFuzz = 10;
-        const fuzzBits = [0, 8, 16, 32, 64, 96, 112];
+        for (const strategy of TIMESTAMP_STRATEGIES) {
+            describe(`Using timestamp strategy ${TIMESTAMP_STRATEGY_NAMES[strategy]}`, function () {
+                beforeEach(async function () {
+                    timestampStrategy = strategy;
+                    aggregator = await deployFunction(timestampStrategy);
+                });
 
-        async function testObservations(observations, from, to) {
-            // Shallow copy observations
-            const observationsCopy = observations.slice();
-            const expectedObservation = await aggregateObservations(AddressZero, observationsCopy, from, to);
-            if (expectedObservation.revertedWith !== undefined) {
-                await expect(aggregator.aggregateObservations(AddressZero, observations, from, to)).to.be.revertedWith(
-                    expectedObservation.revertedWith
-                );
+                const lengths = [1, 2, 3, 5, 8, 9, 16, 17];
+                const nFuzz = 10;
+                const fuzzBits = [0, 8, 64, 96, 112];
 
-                return;
-            }
-
-            const aggregatedObservation = await aggregator.aggregateObservations(AddressZero, observations, from, to);
-            const expectedTimestamp = await currentBlockTimestamp();
-
-            expect(aggregatedObservation.price, "Aggregated price").to.equal(
-                expectedObservation.price,
-                "Expected price"
-            );
-            expect(aggregatedObservation.tokenLiquidity, "Aggregated token liquidity").to.equal(
-                expectedObservation.tokenLiquidity,
-                "Expected token liquidity"
-            );
-            expect(aggregatedObservation.quoteTokenLiquidity, "Aggregated quote token liquidity").to.equal(
-                expectedObservation.quoteTokenLiquidity,
-                "Expected quote token liquidity"
-            );
-            expect(aggregatedObservation.timestamp, "Aggregated timestamp").to.equal(
-                expectedTimestamp,
-                "Expected timestamp"
-            );
-        }
-
-        function generateObservation(price, tokenLiquidity, quoteTokenLiquidity) {
-            return {
-                metadata: {
-                    oracle: AddressZero,
-                },
-                data: {
-                    price: price,
-                    tokenLiquidity: tokenLiquidity,
-                    quoteTokenLiquidity: quoteTokenLiquidity,
-                    timestamp: BigNumber.from(0),
-                },
-            };
-        }
-
-        function generateRandomObservations(num, nBits) {
-            var observations = [];
-
-            for (var i = 0; i < num; i++) {
-                // Generate a random observation
-                const price = getRandomBigNumber(nBits);
-                const tokenLiquidity = getRandomBigNumber(nBits);
-                const quoteTokenLiquidity = getRandomBigNumber(nBits);
-
-                observations.push(generateObservation(price, tokenLiquidity, quoteTokenLiquidity));
-            }
-
-            return observations;
-        }
-
-        for (const length of lengths) {
-            describe("Aggregates " + length + " observations", function () {
-                describe("Using fuzzing", function () {
-                    for (const nBits of fuzzBits) {
-                        it(
-                            "Uses " + nFuzz + " fuzzed observations with " + nBits + " bits of randomness",
-                            async function () {
-                                for (var j = 0; j < nFuzz; j++) {
-                                    const observations = generateRandomObservations(length, nBits);
-
-                                    await testObservations(observations, 0, observations.length - 1);
-                                }
-                            }
-                        );
+                async function calculateExpectedTimestamp(from, to, observations) {
+                    if (from < 0 || to >= observations.length || from > to) {
+                        throw new Error("Invalid range for observations");
                     }
+
+                    if (observations.length === 0) {
+                        throw new Error("No observations provided");
+                    }
+
+                    // Get the timestamps from the observations in the specified range
+                    const timestamps = observations.slice(from, to + 1).map((obs) => obs.data.timestamp);
+
+                    if (timestampStrategy === TIMESTAMP_STRATEGY_THISBLOCK) {
+                        // Return the current block timestamp
+                        return await currentBlockTimestamp();
+                    } else if (timestampStrategy === TIMESTAMP_STRATEGY_EARLIESTOBSERVATION) {
+                        // Return the earliest timestamp in the range
+                        return bigNumberMin(timestamps);
+                    } else if (timestampStrategy === TIMESTAMP_STRATEGY_LATESTOBSERVATION) {
+                        // Return the latest timestamp in the range
+                        return bigNumberMax(timestamps);
+                    } else if (timestampStrategy === TIMESTAMP_STRATEGY_FIRSTOBSERVATION) {
+                        // Return the timestamp of the first observation in the range
+                        return observations[from].data.timestamp;
+                    } else if (timestampStrategy === TIMESTAMP_STRATEGY_LASTOBSERVATION) {
+                        // Return the timestamp of the last observation in the range
+                        return observations[to].data.timestamp;
+                    } else {
+                        throw new Error("Unsupported timestamp strategy");
+                    }
+                }
+
+                async function testObservations(observations, from, to) {
+                    // Shallow copy observations
+                    const observationsCopy = observations.slice();
+                    const expectedObservation = await aggregateObservations(AddressZero, observationsCopy, from, to);
+                    if (expectedObservation.revertedWith !== undefined) {
+                        await expect(
+                            aggregator.aggregateObservations(AddressZero, observations, from, to)
+                        ).to.be.revertedWith(expectedObservation.revertedWith);
+
+                        return;
+                    }
+
+                    const aggregatedObservation = await aggregator.aggregateObservations(
+                        AddressZero,
+                        observations,
+                        from,
+                        to
+                    );
+                    const expectedTimestamp = await calculateExpectedTimestamp(from, to, observations);
+
+                    expect(aggregatedObservation.price, "Aggregated price").to.equal(
+                        expectedObservation.price,
+                        "Expected price"
+                    );
+                    expect(aggregatedObservation.tokenLiquidity, "Aggregated token liquidity").to.equal(
+                        expectedObservation.tokenLiquidity,
+                        "Expected token liquidity"
+                    );
+                    expect(aggregatedObservation.quoteTokenLiquidity, "Aggregated quote token liquidity").to.equal(
+                        expectedObservation.quoteTokenLiquidity,
+                        "Expected quote token liquidity"
+                    );
+                    expect(aggregatedObservation.timestamp, "Aggregated timestamp").to.equal(
+                        expectedTimestamp,
+                        "Expected timestamp"
+                    );
+                }
+
+                function generateObservation(price, tokenLiquidity, quoteTokenLiquidity, timestamp) {
+                    return {
+                        metadata: {
+                            oracle: AddressZero,
+                        },
+                        data: {
+                            price: price,
+                            tokenLiquidity: tokenLiquidity,
+                            quoteTokenLiquidity: quoteTokenLiquidity,
+                            timestamp: timestamp,
+                        },
+                    };
+                }
+
+                function generateRandomObservations(num, nBits) {
+                    var observations = [];
+
+                    for (var i = 0; i < num; i++) {
+                        // Generate a random observation
+                        const price = getRandomBigNumber(nBits);
+                        const tokenLiquidity = getRandomBigNumber(nBits);
+                        const quoteTokenLiquidity = getRandomBigNumber(nBits);
+                        const timestamp = getRandomBigNumber(32); // 32 bits for timestamp
+
+                        observations.push(generateObservation(price, tokenLiquidity, quoteTokenLiquidity, timestamp));
+                    }
+
+                    return observations;
+                }
+
+                for (const length of lengths) {
+                    describe("Aggregates " + length + " observations", function () {
+                        describe("Using fuzzing", function () {
+                            for (const nBits of fuzzBits) {
+                                it(
+                                    "Uses " + nFuzz + " fuzzed observations with " + nBits + " bits of randomness",
+                                    async function () {
+                                        for (var j = 0; j < nFuzz; j++) {
+                                            const observations = generateRandomObservations(length, nBits);
+
+                                            await testObservations(observations, 0, observations.length - 1);
+                                        }
+                                    }
+                                );
+                            }
+                        });
+                    });
+                }
+
+                if (strategy === TIMESTAMP_STRATEGY_THISBLOCK) {
+                    describe("[InvalidTimestamp] Reverts if the block timestamp is too large", function () {
+                        before(async function () {
+                            // Set the timestamp to be very large
+                            const timeTooLarge = 2 ** 32; // Overflows uint32 by 1
+                            await timeAndMine.setTime(timeTooLarge);
+                        });
+
+                        after(async function () {
+                            await network.provider.send("hardhat_reset");
+                        });
+
+                        it("Reverts when using a single observation with a large timestamp", async function () {
+                            const observations = generateRandomObservations(1, MAX_BITS);
+
+                            expect(
+                                aggregator.aggregateObservations(AddressZero, observations, 0, 0)
+                            ).to.be.revertedWith("InvalidTimestamp");
+                        });
+
+                        it("Reverts when using multiple observations with a large timestamp", async function () {
+                            const observations = generateRandomObservations(2, MAX_BITS);
+                            expect(
+                                aggregator.aggregateObservations(AddressZero, observations, 0, 1)
+                            ).to.be.revertedWith("InvalidTimestamp");
+                        });
+                    });
+                }
+
+                describe("Aggregates 1 observation", function () {
+                    for (const length of lengths) {
+                        describe("Using " + length + " observations", function () {
+                            it("Uses the first observation", async function () {
+                                const observations = generateRandomObservations(length, MAX_BITS);
+
+                                await testObservations(observations, 0, 0);
+                            });
+
+                            it("Uses the last observation", async function () {
+                                const observations = generateRandomObservations(length, MAX_BITS);
+
+                                await testObservations(observations, observations.length - 1, observations.length - 1);
+                            });
+
+                            it("Uses a random observation", async function () {
+                                const observations = generateRandomObservations(length, MAX_BITS);
+
+                                const from = Math.floor(Math.random() * observations.length);
+
+                                await testObservations(observations, from, from);
+                            });
+                        });
+                    }
+                });
+
+                it("Reverts if `from` is greater than `to`", async function () {
+                    const observations = generateRandomObservations(2, MAX_BITS);
+
+                    await expect(aggregator.aggregateObservations(AddressZero, observations, 1, 0)).to.be.revertedWith(
+                        "BadInput"
+                    );
+                });
+
+                it("Reverts if `to` is equal to the number of observations", async function () {
+                    const numObservations = 2;
+                    const observations = generateRandomObservations(numObservations, MAX_BITS);
+
+                    await expect(
+                        aggregator.aggregateObservations(AddressZero, observations, 0, numObservations)
+                    ).to.be.revertedWith("InsufficientObservations");
+                });
+
+                it("Reverts if `to` is greater than the number of observations", async function () {
+                    const numObservations = 2;
+                    const observations = generateRandomObservations(numObservations, MAX_BITS);
+
+                    await expect(
+                        aggregator.aggregateObservations(AddressZero, observations, 0, numObservations + 1)
+                    ).to.be.revertedWith("InsufficientObservations");
+                });
+
+                it("Reverts if `from` is equal to the number of observations", async function () {
+                    const numObservations = 2;
+                    const observations = generateRandomObservations(numObservations, MAX_BITS);
+
+                    await expect(
+                        aggregator.aggregateObservations(AddressZero, observations, numObservations, numObservations)
+                    ).to.be.revertedWith("InsufficientObservations");
+                });
+
+                it("Reverts if `from` is greater than the number of observations", async function () {
+                    const numObservations = 2;
+                    const observations = generateRandomObservations(numObservations, MAX_BITS);
+
+                    await expect(
+                        aggregator.aggregateObservations(
+                            AddressZero,
+                            observations,
+                            numObservations + 1,
+                            numObservations + 1
+                        )
+                    ).to.be.revertedWith("InsufficientObservations");
+                });
+
+                it("Reverts if no observations are provided", async function () {
+                    const observations = [];
+
+                    await expect(aggregator.aggregateObservations(AddressZero, observations, 0, 0)).to.be.revertedWith(
+                        "InsufficientObservations"
+                    );
                 });
             });
         }
-
-        describe("Aggregates 1 observation", function () {
-            for (const length of lengths) {
-                describe("Using " + length + " observations", function () {
-                    it("Uses the first observation", async function () {
-                        const observations = generateRandomObservations(length, MAX_BITS);
-
-                        await testObservations(observations, 0, 0);
-                    });
-
-                    it("Uses the last observation", async function () {
-                        const observations = generateRandomObservations(length, MAX_BITS);
-
-                        await testObservations(observations, observations.length - 1, observations.length - 1);
-                    });
-
-                    it("Uses a random observation", async function () {
-                        const observations = generateRandomObservations(length, MAX_BITS);
-
-                        const from = Math.floor(Math.random() * observations.length);
-
-                        await testObservations(observations, from, from);
-                    });
-                });
-            }
-        });
-
-        it("Reverts if `from` is greater than `to`", async function () {
-            const observations = generateRandomObservations(2, MAX_BITS);
-
-            await expect(aggregator.aggregateObservations(AddressZero, observations, 1, 0)).to.be.revertedWith(
-                "BadInput"
-            );
-        });
-
-        it("Reverts if `to` is equal to the number of observations", async function () {
-            const numObservations = 2;
-            const observations = generateRandomObservations(numObservations, MAX_BITS);
-
-            await expect(
-                aggregator.aggregateObservations(AddressZero, observations, 0, numObservations)
-            ).to.be.revertedWith("InsufficientObservations");
-        });
-
-        it("Reverts if `to` is greater than the number of observations", async function () {
-            const numObservations = 2;
-            const observations = generateRandomObservations(numObservations, MAX_BITS);
-
-            await expect(
-                aggregator.aggregateObservations(AddressZero, observations, 0, numObservations + 1)
-            ).to.be.revertedWith("InsufficientObservations");
-        });
-
-        it("Reverts if `from` is equal to the number of observations", async function () {
-            const numObservations = 2;
-            const observations = generateRandomObservations(numObservations, MAX_BITS);
-
-            await expect(
-                aggregator.aggregateObservations(AddressZero, observations, numObservations, numObservations)
-            ).to.be.revertedWith("InsufficientObservations");
-        });
-
-        it("Reverts if `from` is greater than the number of observations", async function () {
-            const numObservations = 2;
-            const observations = generateRandomObservations(numObservations, MAX_BITS);
-
-            await expect(
-                aggregator.aggregateObservations(AddressZero, observations, numObservations + 1, numObservations + 1)
-            ).to.be.revertedWith("InsufficientObservations");
-        });
-
-        it("Reverts if no observations are provided", async function () {
-            const observations = [];
-
-            await expect(aggregator.aggregateObservations(AddressZero, observations, 0, 0)).to.be.revertedWith(
-                "InsufficientObservations"
-            );
-        });
 
         describe(contractName + "#supportsInterface", function () {
             var interfaceIds;
@@ -442,23 +782,23 @@ async function simpleMeanAggregateObservations(token, observations, from, to) {
 }
 
 function createSimpleDeployFunction(contractName) {
-    return async function () {
+    return async function (timestampStrategy) {
         const contractFactory = await ethers.getContractFactory(contractName);
 
-        const contract = await contractFactory.deploy();
+        const contract = await contractFactory.deploy(timestampStrategy);
 
         return contract;
     };
 }
 
 function createDeployFunctionWithAveraging(contractName, averagingStrategyName) {
-    return async function () {
+    return async function (timestampStrategy) {
         const averagingStrategyFactory = await ethers.getContractFactory(averagingStrategyName);
         const averagingStrategy = await averagingStrategyFactory.deploy();
         await averagingStrategy.deployed();
 
         const contractFactory = await ethers.getContractFactory(contractName);
-        const contract = await contractFactory.deploy(averagingStrategy.address);
+        const contract = await contractFactory.deploy(averagingStrategy.address, timestampStrategy);
 
         return contract;
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adraffy/ens-normalize@^1.10.1":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz#42cc67c5baa407ac25059fcd7d405cc5ecdb0c33"
+  integrity sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==
+
 "@atixlabs/hardhat-time-n-mine@^0.0.5":
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@atixlabs/hardhat-time-n-mine/-/hardhat-time-n-mine-0.0.5.tgz#a7956f6f81ae431472d3763303b9cfc7b3040a97"
@@ -108,6 +113,19 @@
     patch-package "^6.2.2"
     postinstall-postinstall "^2.1.0"
 
+"@ethereumjs/rlp@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/rlp/-/rlp-5.0.2.tgz#c89bd82f2f3bec248ab2d517ae25f5bbc4aac842"
+  integrity sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==
+
+"@ethereumjs/util@^9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/util/-/util-9.1.0.tgz#75e3898a3116d21c135fa9e29886565609129bce"
+  integrity sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==
+  dependencies:
+    "@ethereumjs/rlp" "^5.0.2"
+    ethereum-cryptography "^2.2.1"
+
 "@ethersproject/abi@5.0.0-beta.153":
   version "5.0.0-beta.153"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz#43a37172b33794e4562999f6e2d555b7599a8eee"
@@ -138,6 +156,21 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@ethersproject/abi@5.8.0", "@ethersproject/abi@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.8.0.tgz#e79bb51940ac35fe6f3262d7fe2cdb25ad5f07d9"
+  integrity sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==
+  dependencies:
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/hash" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+
 "@ethersproject/abstract-provider@5.7.0", "@ethersproject/abstract-provider@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
@@ -151,6 +184,19 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/web" "^5.7.0"
 
+"@ethersproject/abstract-provider@5.8.0", "@ethersproject/abstract-provider@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz#7581f9be601afa1d02b95d26b9d9840926a35b0c"
+  integrity sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/networks" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    "@ethersproject/web" "^5.8.0"
+
 "@ethersproject/abstract-signer@5.7.0", "@ethersproject/abstract-signer@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
@@ -161,6 +207,17 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/abstract-signer@5.8.0", "@ethersproject/abstract-signer@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz#8d7417e95e4094c1797a9762e6789c7356db0754"
+  integrity sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
 
 "@ethersproject/address@5.7.0", "@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.0.2", "@ethersproject/address@^5.7.0":
   version "5.7.0"
@@ -173,12 +230,30 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/rlp" "^5.7.0"
 
+"@ethersproject/address@5.8.0", "@ethersproject/address@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.8.0.tgz#3007a2c352eee566ad745dca1dbbebdb50a6a983"
+  integrity sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+
 "@ethersproject/base64@5.7.0", "@ethersproject/base64@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
   integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
+
+"@ethersproject/base64@5.8.0", "@ethersproject/base64@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.8.0.tgz#61c669c648f6e6aad002c228465d52ac93ee83eb"
+  integrity sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
 
 "@ethersproject/basex@5.7.0", "@ethersproject/basex@^5.7.0":
   version "5.7.0"
@@ -187,6 +262,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/basex@5.8.0", "@ethersproject/basex@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.8.0.tgz#1d279a90c4be84d1c1139114a1f844869e57d03a"
+  integrity sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
 
 "@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@>=5.0.0-beta.130", "@ethersproject/bignumber@^5.5.0", "@ethersproject/bignumber@^5.7.0":
   version "5.7.0"
@@ -197,6 +280,15 @@
     "@ethersproject/logger" "^5.7.0"
     bn.js "^5.2.1"
 
+"@ethersproject/bignumber@5.8.0", "@ethersproject/bignumber@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.8.0.tgz#c381d178f9eeb370923d389284efa19f69efa5d7"
+  integrity sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    bn.js "^5.2.1"
+
 "@ethersproject/bytes@5.7.0", "@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
@@ -204,12 +296,26 @@
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
+"@ethersproject/bytes@5.8.0", "@ethersproject/bytes@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.8.0.tgz#9074820e1cac7507a34372cadeb035461463be34"
+  integrity sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
+
 "@ethersproject/constants@5.7.0", "@ethersproject/constants@>=5.0.0-beta.128", "@ethersproject/constants@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
   integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
   dependencies:
     "@ethersproject/bignumber" "^5.7.0"
+
+"@ethersproject/constants@5.8.0", "@ethersproject/constants@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.8.0.tgz#12f31c2f4317b113a4c19de94e50933648c90704"
+  integrity sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
 
 "@ethersproject/contracts@5.7.0":
   version "5.7.0"
@@ -227,6 +333,22 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/transactions" "^5.7.0"
 
+"@ethersproject/contracts@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.8.0.tgz#243a38a2e4aa3e757215ea64e276f8a8c9d8ed73"
+  integrity sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==
+  dependencies:
+    "@ethersproject/abi" "^5.8.0"
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+
 "@ethersproject/hash@5.7.0", "@ethersproject/hash@>=5.0.0-beta.128", "@ethersproject/hash@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
@@ -241,6 +363,21 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/hash@5.8.0", "@ethersproject/hash@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.8.0.tgz#b8893d4629b7f8462a90102572f8cd65a0192b4c"
+  integrity sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
 
 "@ethersproject/hdnode@5.7.0", "@ethersproject/hdnode@^5.7.0":
   version "5.7.0"
@@ -259,6 +396,24 @@
     "@ethersproject/strings" "^5.7.0"
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/wordlists" "^5.7.0"
+
+"@ethersproject/hdnode@5.8.0", "@ethersproject/hdnode@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.8.0.tgz#a51ae2a50bcd48ef6fd108c64cbae5e6ff34a761"
+  integrity sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/basex" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/pbkdf2" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/sha2" "^5.8.0"
+    "@ethersproject/signing-key" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    "@ethersproject/wordlists" "^5.8.0"
 
 "@ethersproject/json-wallets@5.7.0", "@ethersproject/json-wallets@^5.7.0":
   version "5.7.0"
@@ -279,6 +434,25 @@
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
+"@ethersproject/json-wallets@5.8.0", "@ethersproject/json-wallets@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.8.0.tgz#d18de0a4cf0f185f232eb3c17d5e0744d97eb8c9"
+  integrity sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/hdnode" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/pbkdf2" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/random" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
 "@ethersproject/keccak256@5.7.0", "@ethersproject/keccak256@>=5.0.0-beta.127", "@ethersproject/keccak256@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
@@ -287,10 +461,23 @@
     "@ethersproject/bytes" "^5.7.0"
     js-sha3 "0.8.0"
 
+"@ethersproject/keccak256@5.8.0", "@ethersproject/keccak256@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.8.0.tgz#d2123a379567faf2d75d2aaea074ffd4df349e6a"
+  integrity sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@5.7.0", "@ethersproject/logger@>=5.0.0-beta.129", "@ethersproject/logger@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
   integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
+
+"@ethersproject/logger@5.8.0", "@ethersproject/logger@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.8.0.tgz#f0232968a4f87d29623a0481690a2732662713d6"
+  integrity sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==
 
 "@ethersproject/networks@5.7.1", "@ethersproject/networks@^5.7.0":
   version "5.7.1"
@@ -298,6 +485,13 @@
   integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/networks@5.8.0", "@ethersproject/networks@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.8.0.tgz#8b4517a3139380cba9fb00b63ffad0a979671fde"
+  integrity sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/pbkdf2@5.7.0", "@ethersproject/pbkdf2@^5.7.0":
   version "5.7.0"
@@ -307,12 +501,27 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/sha2" "^5.7.0"
 
+"@ethersproject/pbkdf2@5.8.0", "@ethersproject/pbkdf2@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.8.0.tgz#cd2621130e5dd51f6a0172e63a6e4a0c0a0ec37e"
+  integrity sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/sha2" "^5.8.0"
+
 "@ethersproject/properties@5.7.0", "@ethersproject/properties@>=5.0.0-beta.131", "@ethersproject/properties@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.7.0.tgz#a6e12cb0439b878aaf470f1902a176033067ed30"
   integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/properties@5.8.0", "@ethersproject/properties@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.8.0.tgz#405a8affb6311a49a91dabd96aeeae24f477020e"
+  integrity sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/providers@5.7.2":
   version "5.7.2"
@@ -340,6 +549,32 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.8.0.tgz#6c2ae354f7f96ee150439f7de06236928bc04cb4"
+  integrity sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/basex" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/hash" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/networks" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/random" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+    "@ethersproject/sha2" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    "@ethersproject/web" "^5.8.0"
+    bech32 "1.1.4"
+    ws "8.18.0"
+
 "@ethersproject/random@5.7.0", "@ethersproject/random@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.7.0.tgz#af19dcbc2484aae078bb03656ec05df66253280c"
@@ -347,6 +582,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/random@5.8.0", "@ethersproject/random@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.8.0.tgz#1bced04d49449f37c6437c701735a1a022f0057a"
+  integrity sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/rlp@5.7.0", "@ethersproject/rlp@^5.7.0":
   version "5.7.0"
@@ -356,6 +599,14 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
 
+"@ethersproject/rlp@5.8.0", "@ethersproject/rlp@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.8.0.tgz#5a0d49f61bc53e051532a5179472779141451de5"
+  integrity sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+
 "@ethersproject/sha2@5.7.0", "@ethersproject/sha2@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
@@ -363,6 +614,15 @@
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+    hash.js "1.1.7"
+
+"@ethersproject/sha2@5.8.0", "@ethersproject/sha2@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.8.0.tgz#8954a613bb78dac9b46829c0a95de561ef74e5e1"
+  integrity sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
     hash.js "1.1.7"
 
 "@ethersproject/signing-key@5.7.0", "@ethersproject/signing-key@^5.7.0":
@@ -377,6 +637,18 @@
     elliptic "6.5.4"
     hash.js "1.1.7"
 
+"@ethersproject/signing-key@5.8.0", "@ethersproject/signing-key@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.8.0.tgz#9797e02c717b68239c6349394ea85febf8893119"
+  integrity sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    bn.js "^5.2.1"
+    elliptic "6.6.1"
+    hash.js "1.1.7"
+
 "@ethersproject/solidity@5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.7.0.tgz#5e9c911d8a2acce2a5ebb48a5e2e0af20b631cb8"
@@ -389,6 +661,18 @@
     "@ethersproject/sha2" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@ethersproject/solidity@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.8.0.tgz#429bb9fcf5521307a9448d7358c26b93695379b9"
+  integrity sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/sha2" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+
 "@ethersproject/strings@5.7.0", "@ethersproject/strings@>=5.0.0-beta.130", "@ethersproject/strings@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
@@ -397,6 +681,15 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/strings@5.8.0", "@ethersproject/strings@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.8.0.tgz#ad79fafbf0bd272d9765603215ac74fd7953908f"
+  integrity sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/transactions@5.7.0", "@ethersproject/transactions@^5.0.0-beta.135", "@ethersproject/transactions@^5.7.0":
   version "5.7.0"
@@ -413,6 +706,21 @@
     "@ethersproject/rlp" "^5.7.0"
     "@ethersproject/signing-key" "^5.7.0"
 
+"@ethersproject/transactions@5.8.0", "@ethersproject/transactions@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.8.0.tgz#1e518822403abc99def5a043d1c6f6fe0007e46b"
+  integrity sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==
+  dependencies:
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+    "@ethersproject/signing-key" "^5.8.0"
+
 "@ethersproject/units@5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.7.0.tgz#637b563d7e14f42deeee39245275d477aae1d8b1"
@@ -421,6 +729,15 @@
     "@ethersproject/bignumber" "^5.7.0"
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/units@5.8.0", "@ethersproject/units@^5.7.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.8.0.tgz#c12f34ba7c3a2de0e9fa0ed0ee32f3e46c5c2c6a"
+  integrity sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/wallet@5.7.0":
   version "5.7.0"
@@ -443,6 +760,27 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/wordlists" "^5.7.0"
 
+"@ethersproject/wallet@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.8.0.tgz#49c300d10872e6986d953e8310dc33d440da8127"
+  integrity sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/hash" "^5.8.0"
+    "@ethersproject/hdnode" "^5.8.0"
+    "@ethersproject/json-wallets" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/random" "^5.8.0"
+    "@ethersproject/signing-key" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    "@ethersproject/wordlists" "^5.8.0"
+
 "@ethersproject/web@5.7.1", "@ethersproject/web@^5.7.0":
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
@@ -453,6 +791,17 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/web@5.8.0", "@ethersproject/web@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.8.0.tgz#3e54badc0013b7a801463a7008a87988efce8a37"
+  integrity sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==
+  dependencies:
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
 
 "@ethersproject/wordlists@5.7.0", "@ethersproject/wordlists@^5.7.0":
   version "5.7.0"
@@ -465,21 +814,81 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@metamask/eth-sig-util@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz#3ad61f6ea9ad73ba5b19db780d40d9aae5157088"
-  integrity sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==
+"@ethersproject/wordlists@5.8.0", "@ethersproject/wordlists@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.8.0.tgz#7a5654ee8d1bb1f4dbe43f91d217356d650ad821"
+  integrity sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==
   dependencies:
-    ethereumjs-abi "^0.6.8"
-    ethereumjs-util "^6.2.1"
-    ethjs-util "^0.1.6"
-    tweetnacl "^1.0.3"
-    tweetnacl-util "^0.15.1"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/hash" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
+"@noble/ciphers@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-1.3.0.tgz#f64b8ff886c240e644e5573c097f86e5b43676dc"
+  integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
+
+"@noble/curves@1.4.2", "@noble/curves@~1.4.0":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.4.2.tgz#40309198c76ed71bc6dbf7ba24e81ceb4d0d1fe9"
+  integrity sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==
+  dependencies:
+    "@noble/hashes" "1.4.0"
+
+"@noble/curves@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.1.tgz#9654a0bc6c13420ae252ddcf975eaf0f58f0a35c"
+  integrity sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==
+  dependencies:
+    "@noble/hashes" "1.8.0"
+
+"@noble/curves@^1.6.0", "@noble/curves@~1.9.0":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.2.tgz#73388356ce733922396214a933ff7c95afcef911"
+  integrity sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==
+  dependencies:
+    "@noble/hashes" "1.8.0"
+
+"@noble/curves@~1.8.1":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.8.2.tgz#8f24c037795e22b90ae29e222a856294c1d9ffc7"
+  integrity sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==
+  dependencies:
+    "@noble/hashes" "1.7.2"
 
 "@noble/hashes@1.2.0", "@noble/hashes@~1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.2.0.tgz#a3150eeb09cc7ab207ebf6d7b9ad311a9bdbed12"
   integrity sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==
+
+"@noble/hashes@1.4.0", "@noble/hashes@~1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+
+"@noble/hashes@1.7.2", "@noble/hashes@~1.7.1":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.2.tgz#d53c65a21658fb02f3303e7ee3ba89d6754c64b4"
+  integrity sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==
+
+"@noble/hashes@1.8.0", "@noble/hashes@^1.5.0", "@noble/hashes@~1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
 "@noble/secp256k1@1.7.1", "@noble/secp256k1@~1.7.0":
   version "1.7.1"
@@ -507,83 +916,53 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nomicfoundation/edr-darwin-arm64@0.3.7":
-  version "0.3.7"
-  resolved "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.3.7.tgz#c204edc79643624dbd431b489b254778817d8244"
-  integrity sha512-6tK9Lv/lSfyBvpEQ4nsTfgxyDT1y1Uv/x8Wa+aB+E8qGo3ToexQ1BMVjxJk6PChXCDOWxB3B4KhqaZFjdhl3Ow==
+"@nomicfoundation/edr-darwin-arm64@0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.11.0.tgz#fa791451c5ce2acf6634143bca9fe8f1b5c66603"
+  integrity sha512-aYTVdcSs27XG7ayTzvZ4Yn9z/ABSaUwicrtrYK2NR8IH0ik4N4bWzo/qH8rax6rewVLbHUkGyGYnsy5ZN4iiMw==
 
-"@nomicfoundation/edr-darwin-x64@0.3.7":
-  version "0.3.7"
-  resolved "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.3.7.tgz#c3b394445084270cc5250d6c1869b0574e7ef810"
-  integrity sha512-1RrQ/1JPwxrYO69e0tglFv5H+ggour5Ii3bb727+yBpBShrxtOTQ7fZyfxA5h62LCN+0Z9wYOPeQ7XFcVurMaQ==
+"@nomicfoundation/edr-darwin-x64@0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.11.0.tgz#b1aaf0bfb331f6d136a92cbe31f184e2209e7a4f"
+  integrity sha512-RxX7UYgvJrfcyT/uHUn44Nsy1XaoW+Q1khKMdHKxeW7BrgIi+Lz+siz3bX5vhSoAnKilDPhIVLrnC8zxQhjR2A==
 
-"@nomicfoundation/edr-linux-arm64-gnu@0.3.7":
-  version "0.3.7"
-  resolved "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.3.7.tgz#6d65545a44d1323bb7ab08c3306947165d2071de"
-  integrity sha512-ds/CKlBoVXIihjhflhgPn13EdKWed6r5bgvMs/YwRqT5wldQAQJZWAfA2+nYm0Yi2gMGh1RUpBcfkyl4pq7G+g==
+"@nomicfoundation/edr-linux-arm64-gnu@0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.11.0.tgz#fef6763c5d42bb68b4fc95df45c4745a0e31df93"
+  integrity sha512-J0j+rs0s11FuSipt/ymqrFmpJ7c0FSz1/+FohCIlUXDxFv//+1R/8lkGPjEYFmy8DPpk/iO8mcpqHTGckREbqA==
 
-"@nomicfoundation/edr-linux-arm64-musl@0.3.7":
-  version "0.3.7"
-  resolved "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.3.7.tgz#5368534bceac1a8c18b1be6b908caca5d39b0c03"
-  integrity sha512-e29udiRaPujhLkM3+R6ju7QISrcyOqpcaxb2FsDWBkuD7H8uU9JPZEyyUIpEp5uIY0Jh1eEJPKZKIXQmQAEAuw==
+"@nomicfoundation/edr-linux-arm64-musl@0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.11.0.tgz#ef89d5d2aefc1f8d4f7c699c59b8897a645d33eb"
+  integrity sha512-4r32zkGMN7WT/CMEuW0VjbuEdIeCskHNDMW4SSgQSJOE/N9L1KSLJCSsAbPD3aYE+e4WRDTyOwmuLjeUTcLZKQ==
 
-"@nomicfoundation/edr-linux-x64-gnu@0.3.7":
-  version "0.3.7"
-  resolved "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.3.7.tgz#42349bf5941dbb54a5719942924c6e4e8cde348e"
-  integrity sha512-/xkjmTyv+bbJ4akBCW0qzFKxPOV4AqLOmqurov+s9umHb16oOv72osSa3SdzJED2gHDaKmpMITT4crxbar4Axg==
+"@nomicfoundation/edr-linux-x64-gnu@0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.11.0.tgz#97432126110aa805b761d4743ab158698cae6d66"
+  integrity sha512-SmdncQHLYtVNWLIMyGaY6LpAfamzTDe3fxjkirmJv3CWR5tcEyC6LMui/GsIVnJzXeNJBXAzwl8hTUAxHTM6kQ==
 
-"@nomicfoundation/edr-linux-x64-musl@0.3.7":
-  version "0.3.7"
-  resolved "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.3.7.tgz#e6babe11c9a8012f1284e6e48c3551861f2a7cd4"
-  integrity sha512-QwBP9xlmsbf/ldZDGLcE4QiAb8Zt46E/+WLpxHBATFhGa7MrpJh6Zse+h2VlrT/SYLPbh2cpHgSmoSlqVxWG9g==
+"@nomicfoundation/edr-linux-x64-musl@0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.11.0.tgz#7605fddbada22dfdd14b15f4ac562014d9c82332"
+  integrity sha512-w6hUqpn/trwiH6SRuRGysj37LsQVCX5XDCA3Xi81sbOaLhbHrNvK9TXWyZmcuzbdTKQQW6VNywcSxDdOiChcJg==
 
-"@nomicfoundation/edr-win32-x64-msvc@0.3.7":
-  version "0.3.7"
-  resolved "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.3.7.tgz#1504b98f305f03be153b0220a546985660de9dc6"
-  integrity sha512-j/80DEnkxrF2ewdbk/gQ2EOPvgF0XSsg8D0o4+6cKhUVAW6XwtWKzIphNL6dyD2YaWEPgIrNvqiJK/aln0ww4Q==
+"@nomicfoundation/edr-win32-x64-msvc@0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.11.0.tgz#6766175f3ec47bfbda0429ca00fed4ae5632a3c4"
+  integrity sha512-BLmULjRKoH9BsX+c4Na2ypV7NGeJ+M6Zpqj/faPOwleVscDdSr/IhriyPaXCe8dyfwbge7lWsbekiADtPSnB2Q==
 
-"@nomicfoundation/edr@^0.3.5":
-  version "0.3.7"
-  resolved "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.3.7.tgz#9c75edf1fcf601617905b2c89acf103f4786d017"
-  integrity sha512-v2JFWnFKRsnOa6PDUrD+sr8amcdhxnG/YbL7LzmgRGU1odWEyOF4/EwNeUajQr4ZNKVWrYnJ6XjydXtUge5OBQ==
-  optionalDependencies:
-    "@nomicfoundation/edr-darwin-arm64" "0.3.7"
-    "@nomicfoundation/edr-darwin-x64" "0.3.7"
-    "@nomicfoundation/edr-linux-arm64-gnu" "0.3.7"
-    "@nomicfoundation/edr-linux-arm64-musl" "0.3.7"
-    "@nomicfoundation/edr-linux-x64-gnu" "0.3.7"
-    "@nomicfoundation/edr-linux-x64-musl" "0.3.7"
-    "@nomicfoundation/edr-win32-x64-msvc" "0.3.7"
-
-"@nomicfoundation/ethereumjs-common@4.0.4":
-  version "4.0.4"
-  resolved "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.4.tgz#9901f513af2d4802da87c66d6f255b510bef5acb"
-  integrity sha512-9Rgb658lcWsjiicr5GzNCjI1llow/7r0k50dLL95OJ+6iZJcVbi15r3Y0xh2cIO+zgX0WIHcbzIu6FeQf9KPrg==
+"@nomicfoundation/edr@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr/-/edr-0.11.0.tgz#d8b0ba4dfd7d93b9c54762e72eb9cd4e8244ce46"
+  integrity sha512-36WERf8ldvyHR6UAbcYsa+vpbW7tCrJGBwF4gXSsb8+STj1n66Hz85Y/O7B9+8AauX3PhglvV5dKl91tk43mWw==
   dependencies:
-    "@nomicfoundation/ethereumjs-util" "9.0.4"
-
-"@nomicfoundation/ethereumjs-rlp@5.0.4":
-  version "5.0.4"
-  resolved "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.4.tgz#66c95256fc3c909f6fb18f6a586475fc9762fa30"
-  integrity sha512-8H1S3s8F6QueOc/X92SdrA4RDenpiAEqMg5vJH99kcQaCy/a3Q6fgseo75mgWlbanGJXSlAPtnCeG9jvfTYXlw==
-
-"@nomicfoundation/ethereumjs-tx@5.0.4":
-  version "5.0.4"
-  resolved "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.4.tgz#b0ceb58c98cc34367d40a30d255d6315b2f456da"
-  integrity sha512-Xjv8wAKJGMrP1f0n2PeyfFCCojHd7iS3s/Ab7qzF1S64kxZ8Z22LCMynArYsVqiFx6rzYy548HNVEyI+AYN/kw==
-  dependencies:
-    "@nomicfoundation/ethereumjs-common" "4.0.4"
-    "@nomicfoundation/ethereumjs-rlp" "5.0.4"
-    "@nomicfoundation/ethereumjs-util" "9.0.4"
-    ethereum-cryptography "0.1.3"
-
-"@nomicfoundation/ethereumjs-util@9.0.4":
-  version "9.0.4"
-  resolved "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.4.tgz#84c5274e82018b154244c877b76bc049a4ed7b38"
-  integrity sha512-sLOzjnSrlx9Bb9EFNtHzK/FJFsfg2re6bsGqinFinH1gCqVfz9YYlXiMWwDM4C/L4ywuHFCYwfKTVr/QHQcU0Q==
-  dependencies:
-    "@nomicfoundation/ethereumjs-rlp" "5.0.4"
-    ethereum-cryptography "0.1.3"
+    "@nomicfoundation/edr-darwin-arm64" "0.11.0"
+    "@nomicfoundation/edr-darwin-x64" "0.11.0"
+    "@nomicfoundation/edr-linux-arm64-gnu" "0.11.0"
+    "@nomicfoundation/edr-linux-arm64-musl" "0.11.0"
+    "@nomicfoundation/edr-linux-x64-gnu" "0.11.0"
+    "@nomicfoundation/edr-linux-x64-musl" "0.11.0"
+    "@nomicfoundation/edr-win32-x64-msvc" "0.11.0"
 
 "@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.1":
   version "0.1.1"
@@ -651,7 +1030,7 @@
     "@nomicfoundation/solidity-analyzer-win32-ia32-msvc" "0.1.1"
     "@nomicfoundation/solidity-analyzer-win32-x64-msvc" "0.1.1"
 
-"@nomiclabs/hardhat-ethers@^2.2.1":
+"@nomiclabs/hardhat-ethers@^2.2.3":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.3.tgz#b41053e360c31a32c2640c9a45ee981a7e603fe0"
   integrity sha512-YhzPdzb612X591FOe68q+qXVXGG2ANZRvDo0RRUtimev85rCrAlv/TLMEZw5c+kq9AbzocLTVX/h2jVIFPL9Xg==
@@ -686,6 +1065,11 @@
   version "3.4.2-solc-0.7"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz#38f4dbab672631034076ccdf2f3201fab1726635"
   integrity sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA==
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@prb/math@^2.5.0":
   version "2.5.0"
@@ -739,6 +1123,16 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
   integrity sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==
 
+"@scure/base@~1.1.6":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
+  integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
+
+"@scure/base@~1.2.5":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
+  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
+
 "@scure/bip32@1.1.5":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.1.5.tgz#d2ccae16dcc2e75bc1d75f5ef3c66a338d1ba300"
@@ -748,6 +1142,24 @@
     "@noble/secp256k1" "~1.7.0"
     "@scure/base" "~1.1.0"
 
+"@scure/bip32@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.4.0.tgz#4e1f1e196abedcef395b33b9674a042524e20d67"
+  integrity sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==
+  dependencies:
+    "@noble/curves" "~1.4.0"
+    "@noble/hashes" "~1.4.0"
+    "@scure/base" "~1.1.6"
+
+"@scure/bip32@1.7.0", "@scure/bip32@^1.5.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.7.0.tgz#b8683bab172369f988f1589640e53c4606984219"
+  integrity sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==
+  dependencies:
+    "@noble/curves" "~1.9.0"
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
+
 "@scure/bip39@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.1.1.tgz#b54557b2e86214319405db819c4b6a370cf340c5"
@@ -755,6 +1167,22 @@
   dependencies:
     "@noble/hashes" "~1.2.0"
     "@scure/base" "~1.1.0"
+
+"@scure/bip39@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.3.0.tgz#0f258c16823ddd00739461ac31398b4e7d6a18c3"
+  integrity sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==
+  dependencies:
+    "@noble/hashes" "~1.4.0"
+    "@scure/base" "~1.1.6"
+
+"@scure/bip39@1.6.0", "@scure/bip39@^1.4.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.6.0.tgz#475970ace440d7be87a6086cbee77cb8f1a684f9"
+  integrity sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==
+  dependencies:
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
 
 "@sentry/core@5.30.0":
   version "5.30.0"
@@ -834,7 +1262,7 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@solidity-parser/parser@^0.14.0", "@solidity-parser/parser@^0.14.1":
+"@solidity-parser/parser@^0.14.0":
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.5.tgz#87bc3cc7b068e08195c219c91cd8ddff5ef1a804"
   integrity sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==
@@ -847,6 +1275,11 @@
   integrity sha512-ESipEcHyRHg4Np4SqBCfcXwyxxna1DgFVz69bgpLV8vzl/NP1DtcKsJ4dJZXWQhY/Z4J2LeKBiOkOVZn9ct33Q==
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
+
+"@solidity-parser/parser@^0.20.1":
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.20.1.tgz#88efee3e0946a4856ed10355017692db9c259ff4"
+  integrity sha512-58I2sRpzaQUN+jJmWbHfbWf9AKfzqCI8JAdFB0vbyY+u8tBRcuTt9LxzasvR0LGQpcRv97eyV7l61FQ3Ib7zVw==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -1055,6 +1488,11 @@ abbrev@1.0.x:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
   integrity sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==
 
+abitype@1.0.8, abitype@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.8.tgz#3554f28b2e9d6e9f35eb59878193eabd1b9f46ba"
+  integrity sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==
+
 abstract-leveldown@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-3.0.0.tgz#5cb89f958a44f526779d740d1440e743e0c30a57"
@@ -1090,11 +1528,6 @@ accepts@~1.3.8:
   dependencies:
     mime-types "~2.1.34"
     negotiator "0.6.3"
-
-address@^1.0.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/address/-/address-1.2.1.tgz#25bb61095b7522d65b357baa11bc05492d4c8acd"
-  integrity sha512-B+6bi5D34+fDYENiH5qOlA0cV2rAGKuWZ9LeyUUehbXy8e0VS9e498yO0Jeeh+iM+6KbfudHTFjXw2MmJD4QRA==
 
 adm-zip@^0.4.16:
   version "0.4.16"
@@ -1168,7 +1601,7 @@ ansi-colors@4.1.1:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
-ansi-colors@^4.1.1:
+ansi-colors@^4.1.1, ansi-colors@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
   integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
@@ -1200,6 +1633,11 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-regex@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.1.0.tgz#95ec409c69619d6cb1b8b34f14b660ef28ebd654"
+  integrity sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -1218,6 +1656,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
+  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
 antlr4@^4.11.0:
   version "4.13.0"
@@ -1291,11 +1734,6 @@ array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
-
-array-uniq@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
-  integrity sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -1410,6 +1848,15 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+
+axios@^1.6.7:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -2105,7 +2552,12 @@ brorand@^1.0.1, brorand@^1.1.0:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
 
-browser-stdout@1.3.1:
+brotli-wasm@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brotli-wasm/-/brotli-wasm-2.0.1.tgz#2b3f4dc3db0c3e60d2635c055e6bac4ddf4bd3f5"
+  integrity sha512-+3USgYsC7bzb5yU0/p2HnnynZl0ak0E6uoIm4UW4Aby/8s8HFCq6NCfrrf1E9c3O8OCSzq3oYO1tUVqIi61Nww==
+
+browser-stdout@1.3.1, browser-stdout@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
@@ -2306,6 +2758,14 @@ cachedown@1.0.0:
     abstract-leveldown "^2.4.1"
     lru-cache "^3.2.0"
 
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
 call-bind@^1.0.0, call-bind@^1.0.2, call-bind@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
@@ -2364,6 +2824,14 @@ chai@^4.3.6:
     pathval "^1.1.1"
     type-detect "^4.0.5"
 
+chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -2383,14 +2851,6 @@ chalk@^2.0.0, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 "charenc@>= 0.0.1":
   version "0.0.2"
@@ -2424,7 +2884,7 @@ chokidar@3.3.0:
   optionalDependencies:
     fsevents "~2.1.1"
 
-chokidar@3.5.3, chokidar@^3.4.0:
+chokidar@3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -2438,6 +2898,28 @@ chokidar@3.5.3, chokidar@^3.4.0:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+chokidar@^3.5.3:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+chokidar@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
+  integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
+  dependencies:
+    readdirp "^4.0.1"
 
 chownr@^1.1.4:
   version "1.1.4"
@@ -2507,6 +2989,15 @@ cli-table3@^0.6.0:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
   integrity sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
+
+cli-table3@^0.6.3:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.5.tgz#013b91351762739c16a9567c21a04632e449bf2f"
+  integrity sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==
   dependencies:
     string-width "^4.2.0"
   optionalDependencies:
@@ -2625,15 +3116,15 @@ command-line-usage@^6.1.0:
     table-layout "^1.0.2"
     typical "^5.2.0"
 
-commander@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
-  integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
-
 commander@^10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
+commander@^8.1.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 complex.js@^2.1.1:
   version "2.1.1"
@@ -2799,6 +3290,15 @@ cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 "crypt@>= 0.0.1":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
@@ -2868,6 +3368,13 @@ debug@^3.1.0:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.5:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
+  integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
+  dependencies:
+    ms "^2.1.3"
 
 decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
@@ -3027,14 +3534,6 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-detect-port@^1.3.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/detect-port/-/detect-port-1.5.1.tgz#451ca9b6eaf20451acb0799b8ab40dff7718727b"
-  integrity sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==
-  dependencies:
-    address "^1.0.1"
-    debug "4"
-
 diff@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
@@ -3044,6 +3543,11 @@ diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
+diff@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
+  integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -3085,10 +3589,24 @@ dotignore@~0.1.2:
   dependencies:
     minimatch "^3.0.4"
 
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
+
 duplexer3@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.5.tgz#0b5e4d7bad5de8901ea4440624c8e1d20099217e"
   integrity sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==
+
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -3121,6 +3639,19 @@ elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.3, elliptic@^6.5
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
+elliptic@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
+  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -3130,6 +3661,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -3222,6 +3758,33 @@ es-array-method-boxes-properly@^1.0.0:
   resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
   integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
 
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  dependencies:
+    es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
+
 es-to-primitive@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
@@ -3277,7 +3840,7 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
 
-escape-string-regexp@4.0.0:
+escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
@@ -3482,7 +4045,7 @@ ethereum-common@^0.0.18:
   resolved "https://registry.yarnpkg.com/ethereum-common/-/ethereum-common-0.0.18.tgz#2fdc3576f232903358976eb39da783213ff9523f"
   integrity sha512-EoltVQTRNg2Uy4o84qpa2aXymXDJhxm7eos/ACOg0DG4baAbMjhbdAEsx9GeE8sC3XCxnYvrrzZDH8D8MtA2iQ==
 
-ethereum-cryptography@0.1.3, ethereum-cryptography@^0.1.3:
+ethereum-cryptography@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz#8d6143cfc3d74bf79bbd8edecdf29e4ae20dd191"
   integrity sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==
@@ -3513,6 +4076,16 @@ ethereum-cryptography@^1.0.3:
     "@scure/bip32" "1.1.5"
     "@scure/bip39" "1.1.1"
 
+ethereum-cryptography@^2.1.3, ethereum-cryptography@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz#58f2810f8e020aecb97de8c8c76147600b0b8ccf"
+  integrity sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==
+  dependencies:
+    "@noble/curves" "1.4.2"
+    "@noble/hashes" "1.4.0"
+    "@scure/bip32" "1.4.0"
+    "@scure/bip39" "1.3.0"
+
 ethereum-waffle@4.0.0-alpha.0:
   version "4.0.0-alpha.0"
   resolved "https://registry.yarnpkg.com/ethereum-waffle/-/ethereum-waffle-4.0.0-alpha.0.tgz#8051a9122b5c4e6479321c758752bdeae3dcd14a"
@@ -3533,7 +4106,7 @@ ethereumjs-abi@0.6.5:
     bn.js "^4.10.0"
     ethereumjs-util "^4.3.0"
 
-ethereumjs-abi@0.6.8, ethereumjs-abi@^0.6.8:
+ethereumjs-abi@0.6.8:
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz#71bc152db099f70e62f108b7cdfca1b362c6fcae"
   integrity sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==
@@ -3630,7 +4203,7 @@ ethereumjs-tx@^1.1.1, ethereumjs-tx@^1.2.0, ethereumjs-tx@^1.2.2, ethereumjs-tx@
     ethereum-common "^0.0.18"
     ethereumjs-util "^5.0.0"
 
-ethereumjs-util@6.2.1, ethereumjs-util@^6.0.0, ethereumjs-util@^6.1.0, ethereumjs-util@^6.2.0, ethereumjs-util@^6.2.1:
+ethereumjs-util@6.2.1, ethereumjs-util@^6.0.0, ethereumjs-util@^6.1.0, ethereumjs-util@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz#fcb4e4dd5ceacb9d2305426ab1a5cd93e3163b69"
   integrity sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==
@@ -3746,7 +4319,7 @@ ethers@^4.0.40:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@^5.5.4, ethers@^5.6.1, ethers@^5.7.2:
+ethers@^5.5.4, ethers@^5.6.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
@@ -3782,6 +4355,42 @@ ethers@^5.5.4, ethers@^5.6.1, ethers@^5.7.2:
     "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
 
+ethers@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.8.0.tgz#97858dc4d4c74afce83ea7562fe9493cedb4d377"
+  integrity sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==
+  dependencies:
+    "@ethersproject/abi" "5.8.0"
+    "@ethersproject/abstract-provider" "5.8.0"
+    "@ethersproject/abstract-signer" "5.8.0"
+    "@ethersproject/address" "5.8.0"
+    "@ethersproject/base64" "5.8.0"
+    "@ethersproject/basex" "5.8.0"
+    "@ethersproject/bignumber" "5.8.0"
+    "@ethersproject/bytes" "5.8.0"
+    "@ethersproject/constants" "5.8.0"
+    "@ethersproject/contracts" "5.8.0"
+    "@ethersproject/hash" "5.8.0"
+    "@ethersproject/hdnode" "5.8.0"
+    "@ethersproject/json-wallets" "5.8.0"
+    "@ethersproject/keccak256" "5.8.0"
+    "@ethersproject/logger" "5.8.0"
+    "@ethersproject/networks" "5.8.0"
+    "@ethersproject/pbkdf2" "5.8.0"
+    "@ethersproject/properties" "5.8.0"
+    "@ethersproject/providers" "5.8.0"
+    "@ethersproject/random" "5.8.0"
+    "@ethersproject/rlp" "5.8.0"
+    "@ethersproject/sha2" "5.8.0"
+    "@ethersproject/signing-key" "5.8.0"
+    "@ethersproject/solidity" "5.8.0"
+    "@ethersproject/strings" "5.8.0"
+    "@ethersproject/transactions" "5.8.0"
+    "@ethersproject/units" "5.8.0"
+    "@ethersproject/wallet" "5.8.0"
+    "@ethersproject/web" "5.8.0"
+    "@ethersproject/wordlists" "5.8.0"
+
 ethjs-unit@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-unit/-/ethjs-unit-0.1.6.tgz#c665921e476e87bce2a9d588a6fe0405b2c41699"
@@ -3790,7 +4399,7 @@ ethjs-unit@0.1.6:
     bn.js "4.11.6"
     number-to-bn "1.7.0"
 
-ethjs-util@0.1.6, ethjs-util@^0.1.3, ethjs-util@^0.1.6:
+ethjs-util@0.1.6, ethjs-util@^0.1.3:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
   integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==
@@ -3802,6 +4411,11 @@ eventemitter3@4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.4.tgz#b5463ace635a083d018bdc7c917b4c5f10a85384"
   integrity sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==
+
+eventemitter3@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
 events@^3.0.0:
   version "3.3.0"
@@ -3970,6 +4584,11 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fdir@^6.4.4:
+  version "6.4.6"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.6.tgz#2b268c0232697063111bbf3f64810a2a741ba281"
+  integrity sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==
+
 fetch-ponyfill@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz#ae3ce5f732c645eab87e4ae8793414709b239893"
@@ -4021,7 +4640,7 @@ find-up@3.0.0, find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-find-up@5.0.0:
+find-up@5.0.0, find-up@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
@@ -4036,13 +4655,6 @@ find-up@^1.0.0:
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
-
-find-up@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
-  integrity sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==
-  dependencies:
-    locate-path "^2.0.0"
 
 find-yarn-workspace-root@^1.2.1:
   version "1.2.1"
@@ -4081,6 +4693,11 @@ follow-redirects@^1.12.1:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 for-each@^0.3.3, for-each@~0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -4092,6 +4709,14 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==
+
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -4114,6 +4739,17 @@ form-data@^3.0.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.3.tgz#608b1b3f3e28be0fccf5901fc85fb3641e5cf0ae"
+  integrity sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
     mime-types "^2.1.12"
 
 form-data@~2.3.2:
@@ -4232,6 +4868,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
 function.prototype.name@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
@@ -4323,10 +4964,34 @@ get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3:
     has "^1.0.3"
     has-symbols "^1.0.3"
 
+get-intrinsic@^1.2.6:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
 get-port@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
   integrity sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 get-stream@^4.1.0:
   version "4.1.0"
@@ -4401,6 +5066,18 @@ glob@7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^10.3.10:
+  version "10.4.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
+  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
+
 glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
@@ -4424,7 +5101,7 @@ glob@^7.0.0, glob@^7.1.3, glob@^7.1.6, glob@~7.2.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.3:
+glob@^8.0.3, glob@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
@@ -4477,6 +5154,11 @@ globby@^10.0.1:
     ignore "^5.1.1"
     merge2 "^1.2.3"
     slash "^3.0.0"
+
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
 got@9.6.0:
   version "9.6.0"
@@ -4561,35 +5243,45 @@ hardhat-contract-sizer@^2.10.0:
     cli-table3 "^0.6.0"
     strip-ansi "^6.0.0"
 
-hardhat-gas-reporter@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.9.tgz#9a2afb354bc3b6346aab55b1c02ca556d0e16450"
-  integrity sha512-INN26G3EW43adGKBNzYWOlI3+rlLnasXTwW79YNnUhXPDa+yHESgt639dJEs37gCjhkbNKcRRJnomXEuMFBXJg==
+hardhat-gas-reporter@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/hardhat-gas-reporter/-/hardhat-gas-reporter-2.3.0.tgz#8605131a9130925b2f19a77576f93a637a2911d8"
+  integrity sha512-ySdA+044xMQv1BlJu5CYXToHzMexKFfIWxlQTBNNoerx1x96+d15IMdN01iQZ/TJ7NH2V5sU73bz77LoS/PEVw==
   dependencies:
-    array-uniq "1.0.3"
-    eth-gas-reporter "^0.2.25"
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/units" "^5.7.0"
+    "@solidity-parser/parser" "^0.20.1"
+    axios "^1.6.7"
+    brotli-wasm "^2.0.1"
+    chalk "4.1.2"
+    cli-table3 "^0.6.3"
+    ethereum-cryptography "^2.1.3"
+    glob "^10.3.10"
+    jsonschema "^1.4.1"
+    lodash "^4.17.21"
+    markdown-table "2.0.0"
     sha1 "^1.1.1"
+    viem "^2.27.0"
 
-hardhat-tracer@^2.8.2:
-  version "2.8.2"
-  resolved "https://registry.npmjs.org/hardhat-tracer/-/hardhat-tracer-2.8.2.tgz#12331b52db4a309ad8040b21bd67e64d2a472c02"
-  integrity sha512-kNi13qdwJsclM9PoIZpZGRGteTFmnVio7xoq3xrca5PWxnQZGO+E1Oig++b6g4gXLkAA3QNFBJip05zsp4qvyQ==
+hardhat-tracer@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/hardhat-tracer/-/hardhat-tracer-3.2.1.tgz#1d8172dd41229fb09d66a8dcadc73bbb19c928da"
+  integrity sha512-nCRCi8zQYDkNw9xDngokbmBmBDNuX9BadgvoRNVgpVpFkriRirdBVinYfBc7P+vufZhNNOjxyIDOPQs+ViRN9Q==
   dependencies:
     chalk "^4.1.2"
     debug "^4.3.4"
     ethers "^5.6.1"
+    semver "^7.6.2"
 
-hardhat@2.22.3:
-  version "2.22.3"
-  resolved "https://registry.npmjs.org/hardhat/-/hardhat-2.22.3.tgz#50605daca6b29862397e446c42ec14c89430bec3"
-  integrity sha512-k8JV2ECWNchD6ahkg2BR5wKVxY0OiKot7fuxiIpRK0frRqyOljcR2vKwgWSLw6YIeDcNNA4xybj7Og7NSxr2hA==
+hardhat@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.24.2.tgz#fe44c0d264557880a4e9e9a03fd03b5b68e95a5a"
+  integrity sha512-oYt+tcN2379Z3kqIhvVw6IFgWqTm/ixcrTvyAuQdE2RbD+kknwF7hDfUeggy0akrw6xdgCtXvnw9DFrxAB70hA==
   dependencies:
+    "@ethereumjs/util" "^9.1.0"
     "@ethersproject/abi" "^5.1.2"
-    "@metamask/eth-sig-util" "^4.0.0"
-    "@nomicfoundation/edr" "^0.3.5"
-    "@nomicfoundation/ethereumjs-common" "4.0.4"
-    "@nomicfoundation/ethereumjs-tx" "5.0.4"
-    "@nomicfoundation/ethereumjs-util" "9.0.4"
+    "@nomicfoundation/edr" "^0.11.0"
     "@nomicfoundation/solidity-analyzer" "^0.1.0"
     "@sentry/node" "^5.18.1"
     "@types/bn.js" "^5.1.0"
@@ -4598,31 +5290,32 @@ hardhat@2.22.3:
     aggregate-error "^3.0.0"
     ansi-escapes "^4.3.0"
     boxen "^5.1.2"
-    chalk "^2.4.2"
-    chokidar "^3.4.0"
+    chokidar "^4.0.0"
     ci-info "^2.0.0"
     debug "^4.1.1"
     enquirer "^2.3.0"
     env-paths "^2.2.0"
     ethereum-cryptography "^1.0.3"
-    ethereumjs-abi "^0.6.8"
-    find-up "^2.1.0"
+    find-up "^5.0.0"
     fp-ts "1.19.3"
     fs-extra "^7.0.1"
-    glob "7.2.0"
     immutable "^4.0.0-rc.12"
     io-ts "1.10.4"
+    json-stream-stringify "^3.1.4"
     keccak "^3.0.2"
     lodash "^4.17.11"
+    micro-eth-signer "^0.14.0"
     mnemonist "^0.38.0"
     mocha "^10.0.0"
     p-map "^4.0.0"
+    picocolors "^1.1.0"
     raw-body "^2.4.1"
     resolve "1.17.0"
     semver "^6.3.0"
-    solc "0.7.3"
+    solc "0.8.26"
     source-map-support "^0.5.13"
     stacktrace-parser "^0.1.10"
+    tinyglobby "^0.2.6"
     tsort "0.0.1"
     undici "^5.14.0"
     uuid "^8.3.2"
@@ -4672,12 +5365,24 @@ has-symbols@^1.0.0, has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
+has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
 has-tostringtag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
   integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
   dependencies:
     has-symbols "^1.0.2"
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -4742,7 +5447,14 @@ hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-he@1.2.0:
+hasown@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
+he@1.2.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -5281,10 +5993,24 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
+isows@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.7.tgz#1c06400b7eed216fbba3bcbd68f12490fc342915"
+  integrity sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
 
 javascript-natural-sort@^0.7.1:
   version "0.7.1"
@@ -5410,6 +6136,11 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
+json-stream-stringify@^3.1.4:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/json-stream-stringify/-/json-stream-stringify-3.1.6.tgz#ebe32193876fb99d4ec9f612389a8d8e2b5d54d4"
+  integrity sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==
+
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -5443,6 +6174,11 @@ jsonschema@^1.2.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
   integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==
+
+jsonschema@^1.4.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.5.0.tgz#f6aceb1ab9123563dd901d05f81f9d4883d3b7d8"
+  integrity sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==
 
 jsprim@^1.2.2:
   version "1.4.2"
@@ -5694,14 +6430,6 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-locate-path@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
-  integrity sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==
-  dependencies:
-    p-locate "^2.0.0"
-    path-exists "^3.0.0"
-
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -5749,7 +6477,7 @@ log-symbols@3.0.0:
   dependencies:
     chalk "^2.4.2"
 
-log-symbols@4.1.0:
+log-symbols@4.1.0, log-symbols@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
   integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
@@ -5798,6 +6526,11 @@ lru-cache@5.1.1, lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 lru-cache@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
@@ -5839,10 +6572,22 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-table@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-2.0.0.tgz#194a90ced26d31fe753d8b9434430214c011865b"
+  integrity sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==
+  dependencies:
+    repeat-string "^1.0.0"
+
 markdown-table@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
+
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
 mathjs@^10.4.0:
   version "10.6.4"
@@ -5944,6 +6689,22 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
+micro-eth-signer@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/micro-eth-signer/-/micro-eth-signer-0.14.0.tgz#8aa1fe997d98d6bdf42f2071cef7eb01a66ecb22"
+  integrity sha512-5PLLzHiVYPWClEvZIXXFu5yutzpadb73rnQCpUqIHu3No3coFuWQNfE5tkBQJ7djuLYl6aRLaS0MgWJYGoqiBw==
+  dependencies:
+    "@noble/curves" "~1.8.1"
+    "@noble/hashes" "~1.7.1"
+    micro-packed "~0.7.2"
+
+micro-packed@~0.7.2:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/micro-packed/-/micro-packed-0.7.3.tgz#59e96b139dffeda22705c7a041476f24cabb12b6"
+  integrity sha512-2Milxs+WNC00TRlem41oRswvw31146GiSaoCT7s3Xi2gMUglW5QBeqlQaZeHr5tJx9nm3i57LNXPqxOOaWtTYg==
+  dependencies:
+    "@scure/base" "~1.2.5"
+
 micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -6044,10 +6805,17 @@ minimatch@5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^5.0.1:
+minimatch@^5.0.1, minimatch@^5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.4:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
+  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -6068,6 +6836,11 @@ minipass@^2.6.0, minipass@^2.9.0:
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
+  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
 minizlib@^1.3.3:
   version "1.3.3"
@@ -6117,36 +6890,6 @@ mnemonist@^0.38.0:
   dependencies:
     obliterator "^2.0.0"
 
-mocha@7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-7.1.2.tgz#8e40d198acf91a52ace122cd7599c9ab857b29e6"
-  integrity sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==
-  dependencies:
-    ansi-colors "3.2.3"
-    browser-stdout "1.3.1"
-    chokidar "3.3.0"
-    debug "3.2.6"
-    diff "3.5.0"
-    escape-string-regexp "1.0.5"
-    find-up "3.0.0"
-    glob "7.1.3"
-    growl "1.10.5"
-    he "1.2.0"
-    js-yaml "3.13.1"
-    log-symbols "3.0.0"
-    minimatch "3.0.4"
-    mkdirp "0.5.5"
-    ms "2.1.1"
-    node-environment-flags "1.0.6"
-    object.assign "4.1.0"
-    strip-json-comments "2.0.1"
-    supports-color "6.0.0"
-    which "1.3.1"
-    wide-align "1.1.3"
-    yargs "13.3.2"
-    yargs-parser "13.1.2"
-    yargs-unparser "1.6.0"
-
 mocha@^10.0.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
@@ -6173,6 +6916,32 @@ mocha@^10.0.0:
     yargs "16.2.0"
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
+
+mocha@^10.2.0:
+  version "10.8.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.8.2.tgz#8d8342d016ed411b12a429eb731b825f961afb96"
+  integrity sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==
+  dependencies:
+    ansi-colors "^4.1.3"
+    browser-stdout "^1.3.1"
+    chokidar "^3.5.3"
+    debug "^4.3.5"
+    diff "^5.2.0"
+    escape-string-regexp "^4.0.0"
+    find-up "^5.0.0"
+    glob "^8.1.0"
+    he "^1.2.0"
+    js-yaml "^4.1.0"
+    log-symbols "^4.1.0"
+    minimatch "^5.1.6"
+    ms "^2.1.3"
+    serialize-javascript "^6.0.2"
+    strip-json-comments "^3.1.1"
+    supports-color "^8.1.1"
+    workerpool "^6.5.1"
+    yargs "^16.2.0"
+    yargs-parser "^20.2.9"
+    yargs-unparser "^2.0.0"
 
 mocha@^7.1.1:
   version "7.2.0"
@@ -6224,7 +6993,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.1.1:
+ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -6560,6 +7329,20 @@ os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
+ox@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.7.1.tgz#fb23a770dd966c051ad916d4e2e655a6f995e1cf"
+  integrity sha512-+k9fY9PRNuAMHRFIUbiK9Nt5seYHHzSQs9Bj+iMETcGtlpS7SmBzcGSVUQO3+nqGLEiNK4598pHNFlVRaZbRsg==
+  dependencies:
+    "@adraffy/ens-normalize" "^1.10.1"
+    "@noble/ciphers" "^1.3.0"
+    "@noble/curves" "^1.6.0"
+    "@noble/hashes" "^1.5.0"
+    "@scure/bip32" "^1.5.0"
+    "@scure/bip39" "^1.4.0"
+    abitype "^1.0.6"
+    eventemitter3 "5.0.1"
+
 p-cancelable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
@@ -6569,13 +7352,6 @@ p-cancelable@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
   integrity sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==
-
-p-limit@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
-  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
-  dependencies:
-    p-try "^1.0.0"
 
 p-limit@^2.0.0:
   version "2.3.0"
@@ -6590,13 +7366,6 @@ p-limit@^3.0.2:
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
-
-p-locate@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
-  integrity sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==
-  dependencies:
-    p-limit "^1.1.0"
 
 p-locate@^3.0.0:
   version "3.0.0"
@@ -6619,15 +7388,15 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
-p-try@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-  integrity sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==
-
 p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -6754,10 +7523,23 @@ path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==
 
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -6799,10 +7581,20 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
 
+picocolors@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -6919,6 +7711,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"
@@ -7167,6 +7964,11 @@ readable-stream@~1.0.15:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
+readdirp@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
+  integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
+
 readdirp@~3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.2.0.tgz#c30c33352b12c96dfb4b895421a49fd5a9593839"
@@ -7267,7 +8069,7 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.4.tgz#be681520847ab58c7568ac75fbfad28ed42d39e9"
   integrity sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==
 
-repeat-string@^1.6.1:
+repeat-string@^1.0.0, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
@@ -7345,7 +8147,7 @@ require-from-string@^1.1.0:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
   integrity sha512-H7AkJWMobeskkttHyhTVtS0fxpFLjxhbfMa6Bk3wimP7sdPRGL3EyCg3sAQenFfAe+xQ+oAc85Nmtvq0ROM83Q==
 
-require-from-string@^2.0.0, require-from-string@^2.0.2:
+require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
@@ -7589,6 +8391,11 @@ semver@^7.3.8:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.6.2:
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
+  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
 semver@~5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
@@ -7617,6 +8424,13 @@ serialize-javascript@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
   integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
+  dependencies:
+    randombytes "^2.1.0"
+
+serialize-javascript@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
   dependencies:
     randombytes "^2.1.0"
 
@@ -7699,10 +8513,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shelljs@^0.8.3:
   version "0.8.5"
@@ -7721,6 +8547,11 @@ side-channel@^1.0.4:
     call-bind "^1.0.0"
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
+
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 simple-concat@^1.0.0:
   version "1.0.1"
@@ -7790,18 +8621,16 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-solc@0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.7.3.tgz#04646961bd867a744f63d2b4e3c0701ffdc7d78a"
-  integrity sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==
+solc@0.8.26:
+  version "0.8.26"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.26.tgz#afc78078953f6ab3e727c338a2fefcd80dd5b01a"
+  integrity sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==
   dependencies:
     command-exists "^1.2.8"
-    commander "3.0.2"
+    commander "^8.1.0"
     follow-redirects "^1.12.1"
-    fs-extra "^0.30.0"
     js-sha3 "0.8.0"
     memorystream "^0.3.1"
-    require-from-string "^2.0.0"
     semver "^5.5.0"
     tmp "0.0.33"
 
@@ -7853,24 +8682,23 @@ solidity-comments-extractor@^0.0.7:
   resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz#99d8f1361438f84019795d928b931f4e5c39ca19"
   integrity sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==
 
-solidity-coverage@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.8.3.tgz#72ce51e5ca9ea1182bbf6085eb1cf526f0603b52"
-  integrity sha512-hbcNgj5z8zzgTlnp4F0pXiqj1v5ua8P4DH5i9cWOBtFPfUuIohLoXu5WiAixexWmpKVjyxXqupnu/mPb4IGr7Q==
+solidity-coverage@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.8.16.tgz#ae07bb11ebbd78d488c7e1a3cd15b8210692f1c9"
+  integrity sha512-qKqgm8TPpcnCK0HCDLJrjbOA2tQNEJY4dHX/LSSQ9iwYFS973MwjtgYn2Iv3vfCEQJTj5xtm4cuUMzlJsJSMbg==
   dependencies:
     "@ethersproject/abi" "^5.0.9"
-    "@solidity-parser/parser" "^0.14.1"
+    "@solidity-parser/parser" "^0.20.1"
     chalk "^2.4.2"
     death "^1.1.0"
-    detect-port "^1.3.0"
     difflib "^0.2.4"
     fs-extra "^8.1.0"
     ghost-testrpc "^0.0.2"
     global-modules "^2.0.0"
     globby "^10.0.1"
     jsonschema "^1.2.4"
-    lodash "^4.17.15"
-    mocha "7.1.2"
+    lodash "^4.17.21"
+    mocha "^10.2.0"
     node-emoji "^1.10.0"
     pify "^4.0.1"
     recursive-readdir "^2.2.2"
@@ -8036,6 +8864,15 @@ string-format@^2.0.0:
   resolved "https://registry.yarnpkg.com/string-format/-/string-format-2.0.0.tgz#f2df2e7097440d3b65de31b6d40d54c96eaffb9b"
   integrity sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==
 
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -8070,6 +8907,15 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
 
 string.prototype.trim@~1.2.6:
   version "1.2.6"
@@ -8117,6 +8963,13 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -8145,6 +8998,13 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
+strip-ansi@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
+  integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
+  dependencies:
+    ansi-regex "^6.0.1"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -8164,7 +9024,7 @@ strip-json-comments@2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
-strip-json-comments@3.1.1:
+strip-json-comments@3.1.1, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -8176,7 +9036,7 @@ supports-color@6.0.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@8.1.1:
+supports-color@8.1.1, supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -8352,6 +9212,14 @@ tiny-emitter@^2.1.0:
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
+tinyglobby@^0.2.6:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.14.tgz#5280b0cf3f972b050e74ae88406c0a6a58f4079d"
+  integrity sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==
+  dependencies:
+    fdir "^6.4.4"
+    picomatch "^4.0.2"
+
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -8463,7 +9331,7 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tweetnacl-util@^0.15.0, tweetnacl-util@^0.15.1:
+tweetnacl-util@^0.15.0:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
   integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==
@@ -8473,7 +9341,7 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==
 
-tweetnacl@^1.0.0, tweetnacl@^1.0.3:
+tweetnacl@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
@@ -8764,6 +9632,20 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+viem@^2.27.0:
+  version "2.31.0"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.31.0.tgz#2263426cce091d440e283b88183dff6f1d8bae5c"
+  integrity sha512-U7OMQ6yqK+bRbEIarf2vqxL7unSEQvNxvML/1zG7suAmKuJmipqdVTVJGKBCJiYsm/EremyO2FS4dHIPpGv+eA==
+  dependencies:
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "1.8.0"
+    "@scure/bip32" "1.7.0"
+    "@scure/bip39" "1.6.0"
+    abitype "1.0.8"
+    isows "1.0.7"
+    ox "0.7.1"
+    ws "8.18.2"
 
 web3-bzz@1.2.11:
   version "1.2.11"
@@ -9113,6 +9995,13 @@ which@1.3.1, which@^1.1.1, which@^1.2.9, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
 wide-align@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
@@ -9155,6 +10044,20 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
+workerpool@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
+  integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -9181,6 +10084,15 @@ wrap-ansi@^7.0.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -9190,6 +10102,16 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+
+ws@8.18.2:
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.2.tgz#42738b2be57ced85f46154320aabb51ab003705a"
+  integrity sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==
 
 ws@^3.0.0:
   version "3.3.3"
@@ -9322,7 +10244,7 @@ yargs-parser@^2.4.1:
     camelcase "^3.0.0"
     lodash.assign "^4.0.6"
 
-yargs-parser@^20.2.2:
+yargs-parser@^20.2.2, yargs-parser@^20.2.9:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
@@ -9336,7 +10258,7 @@ yargs-unparser@1.6.0:
     lodash "^4.17.15"
     yargs "^13.3.0"
 
-yargs-unparser@2.0.0:
+yargs-unparser@2.0.0, yargs-unparser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
   integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
@@ -9362,7 +10284,7 @@ yargs@13.3.2, yargs@^13.3.0:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yargs@16.2.0:
+yargs@16.2.0, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==


### PR DESCRIPTION
### Accumulators
- Update AdrastiaPriceAccumulator
  - Use the heartbeat as the maximum observation age when consulting the underlying oracle.
  - Support instant consultations when `maxAge` is set to 0.
- Update AdrastiaUtilizationAndErrorAccumulator
  - Use the heartbeat as the maximum observation age when consulting the underlying oracle.
  - Support instant consultations when `maxAge` is set to 0.
- Rename VenusIsolatedSBAccumulator to VenusSBAccumulator

### Oracles
- Add VenusOracleView: An oracle view that reads from Venus oracles.
- Add OtfAggregatorOracle: An oracle aggregator that aggregates on-the-fly, rather than serving observations from storage.

### Strategies
#### Aggregation strategies
- Add hardcoded timestamp strategies: Rather than always using the current block timestamp, aggregation strategies can now customize the aggregation timestamp.
  - ThisBlock: Uses the current block timestamp.
  - EarliestObservation: Uses the timestamp of the earliest (oldest) observation.
  - LatestObservation: Uses the timestamp of the latest (newest) observation.
  - FirstObservation: Uses the timestamp of the first observation.
  - LastObservation: Uses the timestamp of the last observation.